### PR TITLE
Install solidus_frontend gem if branch equals main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ branch = ENV.fetch("SOLIDUS_BRANCH", "main")
 gem "solidus", github: "solidusio/solidus", branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
-gem "solidus_frontend", github: "solidusio/solidus_frontend" if branch == "master"
+gem "solidus_frontend", github: "solidusio/solidus_frontend" if branch == "main"
 gem "solidus_frontend" if branch >= "v3.2" # rubocop:disable Bundler/DuplicatedGem
 
 # Needed to help Bundler figure out how to resolve dependencies,


### PR DESCRIPTION
This fixes a bug where solidus_frontend is installed if branch is set to master. However, the default value for SOLIDUS_BRANCH is main, so if its not overwritten then solidus_frontend will not be installed.