### PR TITLE
Initializer: Use new MenuItem API from Solidus 4.2 onwards

### DIFF
--- a/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
+++ b/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
@@ -6,17 +6,40 @@ Spree::Config.promotion_adjuster_class = "SolidusFriendlyPromotions::OrderDiscou
 
 # Replace the promotions menu from core with ours
 Spree::Backend::Config.configure do |config|
-  config.menu_items = Spree::Backend::Config.menu_items.map do |item|
-    next item unless item.url == :admin_promotions_path
+  config.menu_items = config.menu_items.map do |item|
+    next item unless item.label.to_sym == :promotions
 
-    Spree::BackendConfiguration::MenuItem.new(
-      [:promotions, :promotion_categories],
-      'bullhorn',
-      partial: 'spree/admin/shared/promotion_sub_menu',
-      condition: -> { can?(:admin, Spree::Promotion) },
-      url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
-      position: 2
-    )
+    # The API of the MenuItem class changes in Solidus 4.2.0
+    if item.respond_to?(:children)
+      Spree::BackendConfiguration::MenuItem.new(
+        label: :promotions,
+        icon: 'bullhorn',
+        condition: -> { can?(:admin, SolidusFriendlyPromotions::Promotion) },
+        url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
+        data_hook: :admin_promotion_sub_tabs,
+        children: [
+          Spree::BackendConfiguration::MenuItem.new(
+            label: :promotions,
+            url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
+            condition: -> { can?(:admin, SolidusFriendlyPromotions::Promotion) },
+          ),
+          Spree::BackendConfiguration::MenuItem.new(
+            label: :promotion_categories,
+            url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotion_categories_path },
+            condition: -> { can?(:admin, SolidusFriendlyPromotions::PromotionCategory) },
+          ),
+        ],
+      )
+    else
+      Spree::BackendConfiguration::MenuItem.new(
+        [:promotions, :promotion_categories],
+        'bullhorn',
+        partial: 'spree/admin/shared/promotion_sub_menu',
+        condition: -> { can?(:admin, Spree::Promotion) },
+        url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
+        position: 2
+      )
+    end
   end
 end
 


### PR DESCRIPTION
The API for the Menu Item has recently changed in Solidus' `main` branch. This commit makes the initializer work for both APIs.