### PR TITLE
Promotion Actions: Implement "edit" action

### DIFF
--- a/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
+++ b/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
@@ -4,8 +4,8 @@ module SolidusFriendlyPromotions
   module Admin
     class PromotionActionsController < Spree::Admin::BaseController
       before_action :validate_level, only: :new
-      before_action :load_promotion, only: [:create, :destroy, :new, :update]
-      before_action :validate_promotion_action_type, only: :create
+      before_action :load_promotion, only: [:create, :destroy, :new, :update, :edit]
+      before_action :validate_promotion_action_type, only: [:create, :edit]
 
       def new
         if params.dig(:promotion_action, :type)
@@ -29,6 +29,14 @@ module SolidusFriendlyPromotions
         else
           render :new, layout: false
         end
+      end
+
+      def edit
+        @promotion_action = @promotion.actions.find(params[:id])
+        if params.dig(:promotion_action, :calculator_type)
+          @promotion_action.calculator_type = params[:promotion_action][:calculator_type]
+        end
+        render layout: false
       end
 
       def update

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/edit.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/edit.html.erb
@@ -2,30 +2,22 @@
   <div class="promotion_action promotion-block">
     <h6 class='promotion-title'> <%= @promotion_action.class.human_attribute_name(:description) %></h6>
     <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, @promotion_action), method: :delete, class: 'delete' %>
-    <div class="row">
-      <div class="col-6">
-        <%= render 'calculator_select', path: solidus_friendly_promotions.edit_admin_promotion_promotion_action_path(@promotion, @promotion_action), promotion_action: @promotion_action %>
+    <%= render 'calculator_select', path: solidus_friendly_promotions.edit_admin_promotion_promotion_action_path(@promotion, @promotion_action), promotion_action: @promotion_action %>
 
-        <%=
-          form_with(
-            model: @promotion_action,
-            scope: :promotion_action,
-            url: solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, @promotion_action),
-            data: { turbo: false }
-          ) do |form| %>
-          <%= render "form", form: form %>
+    <%=
+      form_with(
+        model: @promotion_action,
+        scope: :promotion_action,
+        url: solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, @promotion_action),
+      ) do |form| %>
+      <%= render "form", form: form %>
 
-          <div class="row">
-            <div class="col-12">
-              <%= button_tag "Update", class: "btn btn-secondary float-right" %>
-            </div>
-          </div>
-
-        <% end %>
+      <div class="row">
+        <div class="col-12">
+          <%= button_tag "Update", class: "btn btn-secondary float-right" %>
+        </div>
       </div>
-      <div class="col-6">
-        BUTTON
-      </div>
-    </div>
+
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Previously, when changing the promotion calculator type for an action, we would end up with an unrescued 500 error. This implements editing an action.