### PR TITLE
Add "Lane" enum to Promotion

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -35,6 +35,16 @@ module SolidusFriendlyPromotions
       post: 2
     }
 
+    def self.human_enum_name(enum_name, enum_value)
+      I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
+    end
+
+    def self.lane_options
+      lanes.map do |lane_name, _index|
+        [human_enum_name(:lane, lane_name), lane_name]
+      end
+    end
+
     self.allowed_ransackable_associations = ["codes"]
     self.allowed_ransackable_attributes = %w[name path promotion_category_id]
     self.allowed_ransackable_scopes = %i[active]

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -29,6 +29,12 @@ module SolidusFriendlyPromotions
       joins(:actions).distinct
     end
 
+    enum lane: {
+      pre: 0,
+      default: 1,
+      post: 2
+    }
+
     self.allowed_ransackable_associations = ["codes"]
     self.allowed_ransackable_attributes = %w[name path promotion_category_id]
     self.allowed_ransackable_scopes = %i[active]

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -40,9 +40,13 @@ module SolidusFriendlyPromotions
     end
 
     def self.lane_options
-      lanes.map do |lane_name, _index|
+      ordered_lanes.map do |lane_name, _index|
         [human_enum_name(:lane, lane_name), lane_name]
       end
+    end
+
+    def self.ordered_lanes
+      lanes.sort_by(&:last).to_h
     end
 
     self.allowed_ransackable_associations = ["codes"]

--- a/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
@@ -68,6 +68,14 @@
           data: { :'enable-time' => true, :'default-hour' => 0 }
         %>
       </div>
+      <div class="field">
+        <%= f.field_container :lane do %>
+          <%= f.label :lane %><br>
+          <%=
+            f.select(:lane, SolidusFriendlyPromotions::Promotion.lane_options, {}, { class: 'custom-select fullwidth' })
+          %>
+        <% end %>
+      </div>
     </div>
   </div>
 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,11 @@ en:
       solidus_friendly_promotions/rules/user_logged_in: User Logged In
       solidus_friendly_promotions/rules/user_role: User Role(s)
     attributes:
+      solidus_friendly_promotions/promotion:
+        lanes:
+          pre: Pre
+          default: Default
+          post: Post
       solidus_friendly_promotions/actions/adjust_line_item:
         description: Creates a promotion credit on matching line items
       solidus_friendly_promotions/actions/adjust_shipment:

--- a/db/migrate/20230928093138_add_lane_to_solidus_friendly_promotions_promotions.rb
+++ b/db/migrate/20230928093138_add_lane_to_solidus_friendly_promotions_promotions.rb
@@ -1,0 +1,5 @@
+class AddLaneToSolidusFriendlyPromotionsPromotions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :friendly_promotions, :lane, :integer, null: false, default: 1
+  end
+end

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   it { is_expected.to belong_to(:category).optional }
   it { is_expected.to have_many :rules }
 
+  describe "lane" do
+    it { is_expected.to respond_to(:lane) }
+
+    it "is default be default" do
+      expect(subject.lane).to eq("default")
+    end
+  end
+
   describe "validations" do
     before do
       @valid_promotion = described_class.new name: "A promotion"

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
     end
   end
 
+  describe ".ordered_lanes" do
+    subject { described_class.ordered_lanes }
+
+    it { is_expected.to eq({"pre" => 0, "default" => 1, "post" => 2}) }
+  end
+
   describe "validations" do
     before do
       @valid_promotion = described_class.new name: "A promotion"


### PR DESCRIPTION
This implements the "lane" concept in the simplest way I can imagine: By just adding an enum with sortable values, we can identify the order in which stacked promotions should be applied. We do not need an additional ActiveRecord model that is sortable, as we don't want to burden administrators with creating and maintaining the lanes, and three lanes should be enough.