### PR TITLE
Reference our own I18n namespace in views

### DIFF
--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_flat_rate/_fields.html.erb
@@ -1,6 +1,7 @@
 <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(:base_amount)}",
   name: "#{prefix}[calculator_attributes][preferred_base_amount]",
-  value: calculator.preferred_base_amount, label: t('spree.base_amount') %>
+  value: calculator.preferred_base_amount,
+  label: calculator.class.human_attribute_name(:preferred_base_amount) %>
 
 <div class="field">
   <%= label_tag(
@@ -18,7 +19,7 @@
 </div>
 
 <div class="field">
-  <%= label_tag nil, t('spree.tiers') %>
+  <%= label_tag nil, calculator.class.human_attribute_name(:tiers) %>
   <div data-controller="calculator-tiers">
     <template data-calculator-tiers-target="template">
       <%= render "solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_flat_rate/tier_fields", tier: [nil, nil], form: form %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_percent/_fields.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_percent/_fields.html.erb
@@ -1,6 +1,7 @@
 <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(:base_percent)}",
   name: "#{prefix}[calculator_attributes][preferred_base_percent]",
-  value: calculator.preferred_base_percent, label: t('spree.base_percent') %>
+  value: calculator.preferred_base_percent,
+  label: calculator.class.human_attribute_name(:preferred_base_percent) %>
 
 <div class="field">
   <%= label_tag(
@@ -18,7 +19,7 @@
 </div>
 
 <div class="field">
-  <%= label_tag nil, t('spree.tiers') %>
+  <%= label_tag nil, calculator.class.human_attribute_name(:tiers)  %>
   <div data-controller="calculator-tiers">
     <template data-calculator-tiers-target="template">
       <%= render "solidus_friendly_promotions/admin/promotion_actions/calculators/tiered_percent/tier_fields", tier: [nil, nil], form: form %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_categories/new.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_categories/new.html.erb
@@ -1,6 +1,6 @@
 <% admin_breadcrumb(link_to plural_resource_name(SolidusFriendlyPromotions::Promotion), solidus_friendly_promotions.admin_promotions_path) %>
 <% admin_breadcrumb(link_to plural_resource_name(SolidusFriendlyPromotions::PromotionCategory), solidus_friendly_promotions.admin_promotion_categories_path) %>
-<% admin_breadcrumb(t('spree.new_promotion_category')) %>
+<% admin_breadcrumb(t('solidus_friendly_promotions.new_promotion_category')) %>
 
 <%= form_for :promotion_category, url: collection_url do |f| %>
   <fieldset class="no-border-top">

--- a/app/views/solidus_friendly_promotions/admin/promotion_codes/index.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_codes/index.html.erb
@@ -5,10 +5,10 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:create, SolidusFriendlyPromotions::PromotionCode) && !@promotion.apply_automatically? %>
-      <%= link_to t('spree.create_promotion_code'), solidus_friendly_promotions.new_admin_promotion_promotion_code_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+      <%= link_to t('solidus_friendly_promotions.create_promotion_code'), solidus_friendly_promotions.new_admin_promotion_promotion_code_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
     <% end %>
 
-    <%= link_to t('spree.download_promotion_codes_list'), solidus_friendly_promotions.admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
+    <%= link_to t('solidus_friendly_promotions.download_promotion_codes_list'), solidus_friendly_promotions.admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
   </li>
 <% end %>
 

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/_type_select.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/_type_select.html.erb
@@ -6,7 +6,7 @@
   ) do |form| %>
   <%= hidden_field_tag :level, @level %>
   <%= form.label :type %>
-  <%= admin_hint t('spree.adjustment_type'), t(:promotions, scope: [:spree, :hints, "spree/calculator"]) %>
+  <%= admin_hint SolidusFriendlyPromotions::PromotionRule.human_attribute_name(:type), t(:promotions, scope: [:solidus_friendly_promotions, :hints, "spree/calculator"]) %>
   <%=
     form.select :type,
       options_for_promotion_rule_types(form.object, level),

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
@@ -1,14 +1,14 @@
 <div class="row">
   <div class="col-12">
     <div class="field products_rule_products">
-      <%= label_tag "#{param_prefix}_product_ids_string", t('spree.product_rule.choose_products') %>
+      <%= label_tag "#{param_prefix}_product_ids_string", t('solidus_friendly_promotions.product_rule.choose_products') %>
       <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
     </div>
   </div>
   <div class="col-12">
     <div class="field">
       <label>
-        <%= t('spree.product_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map{|s| [t("spree.product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product custom-select'})).html_safe %>
+        <%= t('solidus_friendly_promotions.product_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map{|s| [t("solidus_friendly_promotions.product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product custom-select'})).html_safe %>
       </label>
     </div>
   </div>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_store.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_store.html.erb
@@ -1,5 +1,5 @@
 <div class="field">
-  <label><%= t("spree.store_rule.choose_stores" ) %></label>
+  <label><%= t("solidus_friendly_promotions.store_rule.choose_stores" ) %></label>
   <%= select_tag "#{param_prefix}[store_ids][]",
     options_from_collection_for_select(Spree::Store.all, :id, :name, promotion_rule.store_ids),
     multiple: true, class: "select2 fullwidth" %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
@@ -1,9 +1,9 @@
 <div class="field taxons_rule_taxons">
-  <%= label_tag "#{param_prefix}_taxon_ids_string", t('spree.taxon_rule.choose_taxons') %>
+  <%= label_tag "#{param_prefix}_taxon_ids_string", t('solidus_friendly_promotions.taxon_rule.choose_taxons') %>
   <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth", id: 'product_taxon_ids' %>
 </div>
 <div class="field">
   <label>
-    <%= t('spree.taxon_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map{|s| [t("spree.taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon custom-select'})).html_safe %>
+    <%= t('solidus_friendly_promotions.taxon_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map{|s| [t("solidus_friendly_promotions.taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon custom-select'})).html_safe %>
   </label>
 </div>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_user.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_user.html.erb
@@ -1,4 +1,4 @@
 <div class="field">
-  <label><%= t('spree.user_rule.choose_users') %></label><br>
+  <label><%= t('solidus_friendly_promotions.user_rule.choose_users') %></label><br>
   <input type='hidden' name='<%= param_prefix %>[user_ids_string]' class='user_picker fullwidth' value='<%= promotion_rule.user_ids.join(",") %>'>
 </div>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_user_role.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_user_role.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <%= label_tag "#{param_prefix}_preferred_role_ids", t('spree.user_role_rule.choose_roles') %>
+  <%= label_tag "#{param_prefix}_preferred_role_ids", t('solidus_friendly_promotions.user_role_rule.choose_roles') %>
   <%= select_tag "#{param_prefix}[preferred_role_ids]",
     options_from_collection_for_select(
       Spree::Role.all, :id, :name, promotion_rule.preferred_role_ids
@@ -7,6 +7,6 @@
 </div>
 <div class="form-group">
   <label>
-    <%= t('spree.user_role_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::UserRole::MATCH_POLICIES.map{ |s| [t("spree.user_role_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), { class: 'custom-select'})).html_safe %>
+    <%= t('solidus_friendly_promotions.user_role_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::UserRole::MATCH_POLICIES.map{ |s| [t("solidus_friendly_promotions.user_role_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), { class: 'custom-select'})).html_safe %>
   </label>
 </div>

--- a/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
@@ -20,7 +20,7 @@
           <%= f.field_container :category do %>
             <%= f.label :promotion_category_id, SolidusFriendlyPromotions::PromotionCategory.model_name.human %><br>
             <%=
-              f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { include_blank: t('spree.match_choices.none') },
+              f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { include_blank: t('solidus_friendly_promotions.match_choices.none') },
               { class: 'custom-select fullwidth' })
             %>
           <% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotions/index.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/index.html.erb
@@ -6,7 +6,7 @@
       <%= link_to t('solidus_friendly_promotions.new_promotion'), solidus_friendly_promotions.new_admin_promotion_path, class: 'btn btn-primary' %>
     </li>
     <li>
-      <%= link_to t('solidus_friendly_promotions.legacy_promotions'), spree.admin_promotions_path, class: 'btn btn-primary' %>
+      <%= link_to t('solidus_friendly_promotions.legacy_promotions'), solidus_friendly_promotions.admin_promotions_path, class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>
@@ -43,13 +43,13 @@
         <div class="col-2">
           <div class="field">
             <%= label_tag :q_promotion_category_id_eq, SolidusFriendlyPromotions::PromotionCategory.model_name.human %><br>
-            <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: t('spree.match_choices.all') }, { class: 'custom-select fullwidth' }) %>
+            <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: t('solidus_friendly_promotions.match_choices.all') }, { class: 'custom-select fullwidth' }) %>
           </div>
         </div>
 
         <div class="col-2">
           <div class="field">
-            <%= label_tag :active, t('spree.active') %><br>
+            <%= label_tag :active, SolidusFriendlyPromotions::Promotion.human_attribute_name(:active) %><br>
             <%= f.check_box :active, label: false, as: :boolean, checked_value: true %>
           </div>
         </div>
@@ -87,11 +87,11 @@
         <tr id="<%= spree_dom_id promotion %>">
           <td><%= promotion.name %></td>
           <td>
-            <%= (promotion.codes.size == 1) ? promotion.codes.pluck(:value).first : t('spree.number_of_codes', count: promotion.codes.size) %>
+            <%= (promotion.codes.size == 1) ? promotion.codes.pluck(:value).first : t('solidus_friendly_promotions.number_of_codes', count: promotion.codes.size) %>
           </td>
           <td>
             <span class="pill pill-<%= promotion.active? ? 'active' : 'inactive' %>">
-              <%= t(admin_promotion_status(promotion), scope: 'spree.admin.promotion_status') %>
+              <%= t(admin_promotion_status(promotion), scope: 'solidus_friendly_promotions.admin.promotion_status') %>
             </span>
           </td>
           <td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
     new_promotion: New Promotion
     new_promotion_category: New Promotion Category
     new_promotion_code_batch: New Promotion Code Batch
+    number_of_codes: Number of codes
     legacy_promotions: Legacy Promotions
     no_rules_addes: No Rules Added
     promotion_successfully_created: Promotion has been successfully created!
@@ -63,23 +64,28 @@ en:
       update: Update
     admin:
       promotions:
-          actions:
-            calculator_label: Calculated by
-          activations_edit:
-            auto: All orders will attempt to use this promotion
-            multiple_codes_html: This promotion uses %{count} promotion codes
-            single_code_html: 'This promotion uses the promotion code: <code>%{code}</code>'
-          activations_new:
-            auto: Apply to all orders
-            multiple_codes: Multiple promotion codes
-            single_code: Single promotion code
-          form:
-            activation: Activation
-            expires_at_placeholder: Never
-            general: General
-            starts_at_placeholder: Immediately
-          edit:
-            order_rules: Order Rules
+        actions:
+          calculator_label: Calculated by
+        activations_edit:
+          auto: All orders will attempt to use this promotion
+          multiple_codes_html: This promotion uses %{count} promotion codes
+          single_code_html: 'This promotion uses the promotion code: <code>%{code}</code>'
+        activations_new:
+          auto: Apply to all orders
+          multiple_codes: Multiple promotion codes
+          single_code: Single promotion code
+        form:
+          activation: Activation
+          expires_at_placeholder: Never
+          general: General
+          starts_at_placeholder: Immediately
+        edit:
+          order_rules: Order Rules
+        promotion_status:
+          active: Active
+          expired: Expired
+          inactive: Inactive
+          not_started: Not started
     promotion_code_batch_mailer:
       promotion_code_batch_errored:
         message: 'Promotion code batch errored (%{error}) for promotion: '
@@ -114,10 +120,13 @@ en:
       solidus_friendly_promotions/rules/user_role: User Role(s)
     attributes:
       solidus_friendly_promotions/promotion:
+        active: Active
         lanes:
           pre: Pre
           default: Default
           post: Post
+      solidus_friendly_promotions/promotion_action:
+        type: Action Type
       solidus_friendly_promotions/actions/adjust_line_item:
         description: Creates a promotion credit on matching line items
       solidus_friendly_promotions/actions/adjust_shipment:
@@ -126,8 +135,7 @@ en:
         description: Must be the customer's first order
       solidus_friendly_promotions/rules/first_repeat_purchase_since:
         description: Available only to user who have not purchased in a while
-        form_text: 'Apply this promotion to users whose last order was more than X
-          days ago: '
+        form_text: Apply this promotion to users whose last order was more than X days ago
       solidus_friendly_promotions/rules/item_total:
         description: Order total meets these criteria
       solidus_friendly_promotions/rules/landing_page:
@@ -159,6 +167,12 @@ en:
         description: Available only to logged in users
       solidus_friendly_promotions/rules/user_role:
         description: Order includes User with specified Role(s)
+      solidus_friendly_promotions/calculators/tiered_flat_rate:
+        preferred_base_amount: Base Amount
+        tiers: Tiers
+      solidus_friendly_promotions/calculators/tiered_percent:
+        preferred_base_percent: Base Percent
+        tiers: Tiers
     errors:
       models:
         solidus_friendly_promotions/promotion_code:


### PR DESCRIPTION
Prior to this commit, we were still using the translations in core Solidus.