### PR TITLE
Customer label

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -9,7 +9,7 @@ module SolidusFriendlyPromotions
     has_many :codes, class_name: "SolidusFriendlyPromotions::PromotionCode"
     has_many :code_batches, class_name: "SolidusFriendlyPromotions::PromotionCodeBatch"
 
-    validates :name, presence: true
+    validates :name, :customer_label, presence: true
     validates :path, uniqueness: {allow_blank: true, case_sensitive: true}
     validates :usage_limit, numericality: {greater_than: 0, allow_nil: true}
     validates :per_code_usage_limit, numericality: {greater_than_or_equal_to: 0, allow_nil: true}

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -45,7 +45,7 @@ module SolidusFriendlyPromotions
       I18n.t(
         "solidus_friendly_promotions.adjustment_labels.#{adjustable.class.name.demodulize.underscore}",
         promotion: SolidusFriendlyPromotions::Promotion.model_name.human,
-        promotion_name: promotion.name
+        promotion_customer_label: promotion.customer_label
       )
     end
 

--- a/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/_form.html.erb
@@ -9,6 +9,11 @@
             <%= f.text_field :name, class: 'fullwidth', required: true %>
           <% end %>
 
+          <%= f.field_container :customer_label do %>
+            <%= f.label :customer_label, class: 'required' %>
+            <%= f.text_field :customer_label, class: 'fullwidth', required: true %>
+          <% end %>
+
           <%= f.field_container :description do %>
             <%= f.label :description %><br>
             <%= f.text_area :description, rows: 7, class: 'fullwidth' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,7 @@ en:
     attributes:
       solidus_friendly_promotions/promotion:
         active: Active
+        customer_label: Customer-facing label
         lanes:
           pre: Pre
           default: Default

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,8 +5,8 @@ en:
   solidus_friendly_promotions:
     actions: Actions
     adjustment_labels:
-      line_item: "%{promotion} (%{promotion_name})"
-      shipment: "%{promotion} (%{promotion_name})"
+      line_item: "%{promotion} (%{promotion_customer_label})"
+      shipment: "%{promotion} (%{promotion_customer_label})"
     adjustment_type: Adjustment type
     add_action: New Action
     add_rule: New Rule

--- a/db/migrate/20231006134042_add_customer_label_to_promotions.rb
+++ b/db/migrate/20231006134042_add_customer_label_to_promotions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCustomerLabelToPromotions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :friendly_promotions, :customer_label, :string
+  end
+end

--- a/lib/solidus_friendly_promotions/testing_support/friendly_promotion_factory.rb
+++ b/lib/solidus_friendly_promotions/testing_support/friendly_promotion_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :friendly_promotion, class: "SolidusFriendlyPromotions::Promotion" do
     name { "Promo" }
+    customer_label { "Because we like you" }
 
     transient do
       code { nil }

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionAction do
     let(:variant) { create(:variant) }
     let(:order) { create(:order) }
     let(:discountable) { Spree::LineItem.new(order: order, variant: variant, price: 10) }
-    let(:promotion) { SolidusFriendlyPromotions::Promotion.new(name: "20 Perzent off") }
+    let(:promotion) { SolidusFriendlyPromotions::Promotion.new(customer_label: "20 Perzent off") }
     let(:action) { described_class.new(promotion: promotion) }
 
     before do

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   let(:promotion) { described_class.new }
 
   it { is_expected.to belong_to(:category).optional }
+  it { is_expected.to respond_to(:customer_label) }
   it { is_expected.to have_many :rules }
 
   describe "lane" do
@@ -23,26 +24,11 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   end
 
   describe "validations" do
-    before do
-      @valid_promotion = described_class.new name: "A promotion"
-    end
+    subject(:promotion) { build(:friendly_promotion) }
 
-    it "valid_promotion is valid" do
-      expect(@valid_promotion).to be_valid
-    end
-
-    it "validates usage limit" do
-      @valid_promotion.usage_limit = -1
-      expect(@valid_promotion).not_to be_valid
-
-      @valid_promotion.usage_limit = 100
-      expect(@valid_promotion).to be_valid
-    end
-
-    it "validates name" do
-      @valid_promotion.name = nil
-      expect(@valid_promotion).not_to be_valid
-    end
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:customer_label) }
+    it { is_expected.to validate_numericality_of(:usage_limit).is_greater_than(0) }
   end
 
   describe ".advertised" do

--- a/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
+++ b/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
@@ -81,12 +81,13 @@ RSpec.describe "Promotions admin", type: :system do
       expect(page).to have_field("Starts at")
       expect(page).to have_field("Expires at")
       expect(page).to have_field("Description")
-      fill_in("Name", with: "20 percent off")
+      fill_in("Name", with: "March 2023 Giveaway")
+      fill_in("Customer-facing label", with: "20 percent off")
       fill_in("Starts at", with: Time.current)
       fill_in("Expires at", with: 1.week.from_now)
       choose("Apply to all orders")
       click_button("Create")
-      expect(page).to have_content("20 percent off")
+      expect(page).to have_content("March 2023 Giveaway")
       promotion = SolidusFriendlyPromotions::Promotion.first
       within("#promotion_#{promotion.id}_new_order_promotion_rule") do
         click_link("New Rule")


### PR DESCRIPTION
This adds a "customer_label" column to the promotion model, allowing admins to name their promotions independently of the customer experience.