### PR TITLE
Require solidus

### DIFF
--- a/app/views/solidus_friendly_promotions/admin/promotions/index.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/index.html.erb
@@ -5,9 +5,6 @@
     <li>
       <%= link_to t('solidus_friendly_promotions.new_promotion'), solidus_friendly_promotions.new_admin_promotion_path, class: 'btn btn-primary' %>
     </li>
-    <li>
-      <%= link_to t('solidus_friendly_promotions.legacy_promotions'), solidus_friendly_promotions.admin_promotions_path, class: 'btn btn-primary' %>
-    </li>
   <% end %>
 <% end %>
 

--- a/app/views/solidus_friendly_promotions/admin/shared/_promotion_sub_menu.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/shared/_promotion_sub_menu.html.erb
@@ -1,0 +1,8 @@
+<ul class="admin-subnav" data-hook="admin_promotion_sub_tabs">
+  <% if can? :admin, SolidusFriendlyPromotions::Promotion %>
+    <%= tab url: solidus_friendly_promotions.admin_promotions_path, label: :promotions %>
+  <% end %>
+  <% if can? :admin, SolidusFriendlyPromotions::PromotionCategory %>
+    <%= tab url: solidus_friendly_promotions.admin_promotion_categories_path, label: :promotion_categories %>
+  <% end %>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,11 +81,11 @@ en:
           starts_at_placeholder: Immediately
         edit:
           order_rules: Order Rules
-        promotion_status:
-          active: Active
-          expired: Expired
-          inactive: Inactive
-          not_started: Not started
+      promotion_status:
+        active: Active
+        expired: Expired
+        inactive: Inactive
+        not_started: Not started
     promotion_code_batch_mailer:
       promotion_code_batch_errored:
         message: 'Promotion code batch errored (%{error}) for promotion: '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,13 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  spree:
+    admin:
+      tab:
+        promotions: Promotions
+        promotion_categories: Promotion Categories
+        legacy_promotions: Legacy Promotions
+        legacy_promotion_categories: Legacy Promotion Categories
   solidus_friendly_promotions:
     actions: Actions
     adjustment_labels:

--- a/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
+++ b/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
@@ -34,8 +34,8 @@ Spree::Backend::Config.configure do |config|
       Spree::BackendConfiguration::MenuItem.new(
         [:promotions, :promotion_categories],
         "bullhorn",
-        partial: "spree/admin/shared/promotion_sub_menu",
-        condition: -> { can?(:admin, Spree::Promotion) },
+        partial: "solidus_friendly_promotions/admin/shared/promotion_sub_menu",
+        condition: -> { can?(:admin, SolidusFriendlyPromotions::Promotion) },
         url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
         position: 2
       )

--- a/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
+++ b/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
@@ -27,6 +27,18 @@ Spree::Backend::Config.configure do |config|
             label: :promotion_categories,
             url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotion_categories_path },
             condition: -> { can?(:admin, SolidusFriendlyPromotions::PromotionCategory) }
+          ),
+          Spree::BackendConfiguration::MenuItem.new(
+            label: :legacy_promotions,
+            condition: -> { can?(:admin, Spree::Promotion && Spree::Promotion.any?) },
+            url: -> { Spree::Core::Engine.routes.url_helpers.admin_promotions_path },
+            match_path: '/admin/promotions/'
+          ),
+          Spree::BackendConfiguration::MenuItem.new(
+            label: :legacy_promotion_categories,
+            condition: -> { can?(:admin, Spree::PromotionCategory && Spree::Promotion.any?) },
+            url: -> { Spree::Core::Engine.routes.url_helpers.admin_promotion_categories_path },
+            match_path: '/admin/promotion_categories/'
           )
         ]
       )

--- a/lib/solidus_friendly_promotions.rb
+++ b/lib/solidus_friendly_promotions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require "spree"
+require "solidus_core"
+require "solidus_backend"
+require "solidus_support"
 require "turbo-rails"
 require "importmap-rails"
 require "stimulus-rails"


### PR DESCRIPTION
Requiring `spree` results in a load error in real life.