### PR TITLE
Add "only" match policy to product rule

### DIFF
--- a/app/models/solidus_friendly_promotions/rules/product.rb
+++ b/app/models/solidus_friendly_promotions/rules/product.rb
@@ -17,7 +17,7 @@ module SolidusFriendlyPromotions
         [:products]
       end
 
-      MATCH_POLICIES = %w[any all none].freeze
+      MATCH_POLICIES = %w[any all none only].freeze
 
       validates :preferred_match_policy, inclusion: {in: MATCH_POLICIES}
 
@@ -47,6 +47,11 @@ module SolidusFriendlyPromotions
           end
         when "none"
           unless order_products(order).none? { |product| eligible_products.include?(product) }
+            eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product),
+              error_code: :has_excluded_product)
+          end
+        when "only"
+          unless order_products(order).all? { |product| eligible_products.include?(product) }
             eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product),
               error_code: :has_excluded_product)
           end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,10 +45,11 @@ en:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
     product_rule:
       choose_products: Choose products
-      label: Order must contain %{select} of these products
-      match_all: all
-      match_any: at least one
-      match_none: none
+      label: Order must contain %{select} these products
+      match_all: all of
+      match_any: at least one of
+      match_none: none of
+      match_only: only
       product_source:
         group: From product group
         manual: Manually choose


### PR DESCRIPTION
This addition to the order product rule makes the rule match if the order contains exclusively the products specified in the rule.