### PR TITLE
Add PermissionSet for Friendly Promotions

### DIFF
--- a/app/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
+++ b/app/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module PermissionSets
+    class FriendlyPromotionManagement < Spree::PermissionSets::Base
+      def activate!
+        can :manage, SolidusFriendlyPromotions::Promotion
+        can :manage, SolidusFriendlyPromotions::PromotionRule
+        can :manage, SolidusFriendlyPromotions::PromotionAction
+        can :manage, SolidusFriendlyPromotions::PromotionCategory
+        can :manage, SolidusFriendlyPromotions::PromotionCode
+      end
+    end
+  end
+end

--- a/spec/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
+++ b/spec/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cancan/matchers"
+
+RSpec.describe SolidusFriendlyPromotions::PermissionSets::FriendlyPromotionManagement do
+  let(:ability_klass) do
+    Class.new do
+      include CanCan::Ability
+    end
+  end
+  let(:ability) { ability_klass.new }
+
+  subject { ability }
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:manage, SolidusFriendlyPromotions::Promotion) }
+    it { is_expected.to be_able_to(:manage, SolidusFriendlyPromotions::PromotionRule) }
+    it { is_expected.to be_able_to(:manage, SolidusFriendlyPromotions::PromotionAction) }
+    it { is_expected.to be_able_to(:manage, SolidusFriendlyPromotions::PromotionCategory) }
+    it { is_expected.to be_able_to(:manage, SolidusFriendlyPromotions::PromotionCode) }
+  end
+
+  context "when not activated" do
+    it { is_expected.not_to be_able_to(:manage, SolidusFriendlyPromotions::Promotion) }
+    it { is_expected.not_to be_able_to(:manage, SolidusFriendlyPromotions::PromotionRule) }
+    it { is_expected.not_to be_able_to(:manage, SolidusFriendlyPromotions::PromotionAction) }
+    it { is_expected.not_to be_able_to(:manage, SolidusFriendlyPromotions::PromotionCategory) }
+    it { is_expected.not_to be_able_to(:manage, SolidusFriendlyPromotions::PromotionCode) }
+  end
+end


### PR DESCRIPTION
This can be used to allow other roles than admin the ability to manage Friendly Promotions.