### PR TITLE
Fix class name option in line item taxon association

### DIFF
--- a/app/models/solidus_friendly_promotions/rules/line_item_product.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_product.rb
@@ -9,7 +9,7 @@ module SolidusFriendlyPromotions
       has_many :product_promotion_rules,
         dependent: :destroy,
         foreign_key: :promotion_rule_id,
-        class_name: "Spree::ProductPromotionRule"
+        class_name: "SolidusFriendlyPromotions::ProductsPromotionRule"
       has_many :products,
         class_name: "Spree::Product",
         through: :product_promotion_rules

--- a/app/models/solidus_friendly_promotions/rules/line_item_taxon.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_taxon.rb
@@ -3,7 +3,7 @@
 module SolidusFriendlyPromotions
   module Rules
     class LineItemTaxon < PromotionRule
-      has_many :promotion_rule_taxons, class_name: "Spree::PromotionRuleTaxon", foreign_key: :promotion_rule_id,
+      has_many :promotion_rule_taxons, class_name: "SolidusFriendlyPromotions::PromotionRulesTaxon", foreign_key: :promotion_rule_id,
         dependent: :destroy
       has_many :taxons, through: :promotion_rule_taxons, class_name: "Spree::Taxon"
 


### PR DESCRIPTION
This went through the legacy join table, but has to go through the new join table.