### PR TITLE
Allow destroying promotions

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -4,10 +4,10 @@ module SolidusFriendlyPromotions
   class Promotion < Spree::Base
     belongs_to :category, class_name: "SolidusFriendlyPromotions::PromotionCategory",
       foreign_key: :promotion_category_id, optional: true
-    has_many :rules, class_name: "SolidusFriendlyPromotions::PromotionRule"
-    has_many :actions, class_name: "SolidusFriendlyPromotions::PromotionAction"
-    has_many :codes, class_name: "SolidusFriendlyPromotions::PromotionCode"
-    has_many :code_batches, class_name: "SolidusFriendlyPromotions::PromotionCodeBatch"
+    has_many :rules, class_name: "SolidusFriendlyPromotions::PromotionRule", dependent: :destroy
+    has_many :actions, class_name: "SolidusFriendlyPromotions::PromotionAction", dependent: :nullify
+    has_many :codes, class_name: "SolidusFriendlyPromotions::PromotionCode", dependent: :destroy
+    has_many :code_batches, class_name: "SolidusFriendlyPromotions::PromotionCodeBatch", dependent: :destroy
 
     validates :name, :customer_label, presence: true
     validates :path, uniqueness: {allow_blank: true, case_sensitive: true}

--- a/db/migrate/20231011154553_allow_null_promotion_ids.rb
+++ b/db/migrate/20231011154553_allow_null_promotion_ids.rb
@@ -1,0 +1,9 @@
+class AllowNullPromotionIds < ActiveRecord::Migration[7.0]
+  def up
+    change_column_null :friendly_promotion_actions, :promotion_id, true
+  end
+
+  def down
+    change_column_null :friendly_promotion_actions, :promotion_id, false
+  end
+end

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
     end
   end
 
+  describe "#destroy" do
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+
+    subject { promotion.destroy! }
+
+    it "destroys the promotion and nullifies the action" do
+      expect { subject }.to change { SolidusFriendlyPromotions::Promotion.count }.by(-1)
+      expect(SolidusFriendlyPromotions::PromotionAction.count).to eq(1)
+      expect(SolidusFriendlyPromotions::PromotionAction.first.promotion_id).to be nil
+    end
+  end
+
   describe ".ordered_lanes" do
     subject { described_class.ordered_lanes }
 


### PR DESCRIPTION
Currently, promotions cannot be destroyed as soon as the have dependent records. This sets `dependent: :destroy` on all important relations except for `actions`, which are soft-deletable, and thus need to be nullified instead.

Alternatively, we could make all tables soft-deleteable, which would be better for auditing. If a promotion gets applied, and we have an adjustment with a promotion action as its source, and then we delete the promotion action's promotion, we will end up with an "orphan" promotion action.

Promotion actions need to be soft-deleteable, because if they are deleted, they might nullify - or worse - delete adjustments on orders.