### PR TITLE
Polyvalent rules

### DIFF
--- a/app/helpers/solidus_friendly_promotions/admin/promotion_rules_helper.rb
+++ b/app/helpers/solidus_friendly_promotions/admin/promotion_rules_helper.rb
@@ -12,8 +12,13 @@ module SolidusFriendlyPromotions
 
       def promotion_rules_by_level(promotion, level)
         promotion.rules.select do |rule|
-          rule.class.in?(SolidusFriendlyPromotions.config.send("#{level}_rules").to_a)
+          rule.level == level || rule_applicable_by_preference(rule, level)
         end
+      end
+
+      def rule_applicable_by_preference(rule, level)
+        method_name = "preferred_#{level}_applicable"
+        rule.respond_to?(method_name) && rule.send(method_name)
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -24,6 +24,10 @@ module SolidusFriendlyPromotions
       raise NotImplementedError, "eligible? should be implemented in a sub-class of SolidusFriendlyPromotions::Rule"
     end
 
+    def level
+      raise NotImplementedError, "level should be implemented in a sub-class of SolidusFriendlyPromotions::Rule"
+    end
+
     def eligibility_errors
       @eligibility_errors ||= ActiveModel::Errors.new(self)
     end

--- a/app/models/solidus_friendly_promotions/rules/first_order.rb
+++ b/app/models/solidus_friendly_promotions/rules/first_order.rb
@@ -3,11 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class FirstOrder < PromotionRule
+      include OrderLevelRule
       attr_reader :user, :email
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
 
       def eligible?(order, options = {})
         @user = order.try(:user) || options[:user]

--- a/app/models/solidus_friendly_promotions/rules/first_repeat_purchase_since.rb
+++ b/app/models/solidus_friendly_promotions/rules/first_repeat_purchase_since.rb
@@ -3,13 +3,10 @@
 module SolidusFriendlyPromotions
   module Rules
     class FirstRepeatPurchaseSince < PromotionRule
+      include OrderLevelRule
+
       preference :days_ago, :integer, default: 365
       validates :preferred_days_ago, numericality: {only_integer: true, greater_than: 0}
-
-      # This promotion is applicable to orders only.
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
 
       # This is never eligible if the order does not have a user, and that user does not have any previous completed orders.
       #

--- a/app/models/solidus_friendly_promotions/rules/item_total.rb
+++ b/app/models/solidus_friendly_promotions/rules/item_total.rb
@@ -8,6 +8,8 @@ module SolidusFriendlyPromotions
     # To add extra operators please override `self.operators_map` or any other helper method.
     # To customize the error message you can also override `ineligible_message`.
     class ItemTotal < PromotionRule
+      include OrderLevelRule
+
       preference :amount, :decimal, default: 100.00
       preference :currency, :string, default: -> { Spree::Config[:currency] }
       preference :operator, :string, default: "gt"
@@ -24,10 +26,6 @@ module SolidusFriendlyPromotions
         operators_map.map do |name, _method|
           [I18n.t(name, scope: "spree.item_total_rule.operators"), name]
         end
-      end
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
       end
 
       def eligible?(order, _options = {})

--- a/app/models/solidus_friendly_promotions/rules/line_item_applicable_order_rule.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_applicable_order_rule.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module Rules
+    module LineItemApplicableOrderRule
+      def self.included(klass)
+        klass.preference :line_item_applicable, :boolean, default: true
+      end
+
+      def applicable?(promotable)
+        promotable.is_a?(Spree::Order) || preferred_line_item_applicable && promotable.is_a?(Spree::LineItem)
+      end
+
+      def eligible?(promotable)
+        send("#{promotable.class.name.demodulize.underscore}_eligible?", promotable)
+      end
+
+      def level
+        :order
+      end
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/rules/line_item_level_rule.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_level_rule.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module Rules
+    module LineItemLevelRule
+      def applicable?(promotable)
+        promotable.is_a?(Spree::LineItem)
+      end
+
+      def level
+        :line_item
+      end
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/rules/line_item_option_value.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_option_value.rb
@@ -3,11 +3,9 @@
 module SolidusFriendlyPromotions
   module Rules
     class LineItemOptionValue < PromotionRule
-      preference :eligible_values, :hash
+      include LineItemLevelRule
 
-      def applicable?(promotable)
-        promotable.is_a?(Spree::LineItem)
-      end
+      preference :eligible_values, :hash
 
       def eligible?(line_item, _options = {})
         pid = line_item.product.id

--- a/app/models/solidus_friendly_promotions/rules/line_item_product.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_product.rb
@@ -4,6 +4,8 @@ module SolidusFriendlyPromotions
   module Rules
     # A rule to apply a promotion only to line items with or without a chosen product
     class LineItemProduct < PromotionRule
+      include LineItemLevelRule
+
       MATCH_POLICIES = %w[include exclude].freeze
 
       has_many :product_promotion_rules,
@@ -15,10 +17,6 @@ module SolidusFriendlyPromotions
         through: :product_promotion_rules
 
       preference :match_policy, :string, default: MATCH_POLICIES.first
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::LineItem)
-      end
 
       def eligible?(line_item, _options = {})
         if inverse?
@@ -34,10 +32,6 @@ module SolidusFriendlyPromotions
 
       def product_ids_string=(product_ids)
         self.product_ids = product_ids.to_s.split(",").map(&:strip)
-      end
-
-      def updateable?
-        true
       end
 
       private

--- a/app/models/solidus_friendly_promotions/rules/line_item_taxon.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_taxon.rb
@@ -3,6 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class LineItemTaxon < PromotionRule
+      include LineItemLevelRule
+
       has_many :promotion_rule_taxons, class_name: "SolidusFriendlyPromotions::PromotionRulesTaxon", foreign_key: :promotion_rule_id,
         dependent: :destroy
       has_many :taxons, through: :promotion_rule_taxons, class_name: "Spree::Taxon"
@@ -12,9 +14,6 @@ module SolidusFriendlyPromotions
       validates :preferred_match_policy, inclusion: {in: MATCH_POLICIES}
 
       preference :match_policy, :string, default: MATCH_POLICIES.first
-      def applicable?(promotable)
-        promotable.is_a?(Spree::LineItem)
-      end
 
       def eligible?(line_item, _options = {})
         found = Spree::Classification.where(

--- a/app/models/solidus_friendly_promotions/rules/nth_order.rb
+++ b/app/models/solidus_friendly_promotions/rules/nth_order.rb
@@ -3,15 +3,12 @@
 module SolidusFriendlyPromotions
   module Rules
     class NthOrder < PromotionRule
+      include OrderLevelRule
+
       preference :nth_order, :integer, default: 2
       # It does not make sense to have this apply to the first order using preferred_nth_order == 1
       # Instead we could use the first_order rule
       validates :preferred_nth_order, numericality: {only_integer: true, greater_than: 1}
-
-      # This promotion is applicable to orders only.
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
 
       # This is never eligible if the order does not have a user, and that user does not have any previous completed orders.
       #

--- a/app/models/solidus_friendly_promotions/rules/one_use_per_user.rb
+++ b/app/models/solidus_friendly_promotions/rules/one_use_per_user.rb
@@ -3,9 +3,7 @@
 module SolidusFriendlyPromotions
   module Rules
     class OneUsePerUser < PromotionRule
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
+      include OrderLevelRule
 
       def eligible?(order, _options = {})
         if order.user.present?

--- a/app/models/solidus_friendly_promotions/rules/option_value.rb
+++ b/app/models/solidus_friendly_promotions/rules/option_value.rb
@@ -3,11 +3,9 @@
 module SolidusFriendlyPromotions
   module Rules
     class OptionValue < PromotionRule
-      preference :eligible_values, :hash
+      include OrderLevelRule
 
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
+      preference :eligible_values, :hash
 
       def eligible?(order, _options = {})
         order.line_items.any? do |item|

--- a/app/models/solidus_friendly_promotions/rules/option_value.rb
+++ b/app/models/solidus_friendly_promotions/rules/option_value.rb
@@ -3,14 +3,16 @@
 module SolidusFriendlyPromotions
   module Rules
     class OptionValue < PromotionRule
-      include OrderLevelRule
+      include LineItemApplicableOrderRule
 
       preference :eligible_values, :hash
 
-      def eligible?(order, _options = {})
-        order.line_items.any? do |item|
-          LineItemOptionValue.new(preferred_eligible_values: preferred_eligible_values).eligible?(item)
-        end
+      def order_eligible?(order)
+        order.line_items.any? { |item| line_item_eligible?(item) }
+      end
+
+      def line_item_eligible?(line_item)
+        LineItemOptionValue.new(preferred_eligible_values: preferred_eligible_values).eligible?(line_item)
       end
 
       def preferred_eligible_values

--- a/app/models/solidus_friendly_promotions/rules/order_level_rule.rb
+++ b/app/models/solidus_friendly_promotions/rules/order_level_rule.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module Rules
+    module OrderLevelRule
+      def applicable?(promotable)
+        promotable.is_a?(Spree::Order)
+      end
+
+      def level
+        :order
+      end
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/rules/product.rb
+++ b/app/models/solidus_friendly_promotions/rules/product.rb
@@ -7,6 +7,8 @@ module SolidusFriendlyPromotions
     # either come from assigned product group or are assingned directly to
     # the rule.
     class Product < PromotionRule
+      include OrderLevelRule
+
       has_many :products_promotion_rules,
         dependent: :destroy,
         foreign_key: :promotion_rule_id,
@@ -80,10 +82,6 @@ module SolidusFriendlyPromotions
 
       def product_ids_string=(product_ids)
         self.product_ids = product_ids.to_s.split(",").map(&:strip)
-      end
-
-      def updateable?
-        true
       end
 
       private

--- a/app/models/solidus_friendly_promotions/rules/product.rb
+++ b/app/models/solidus_friendly_promotions/rules/product.rb
@@ -7,7 +7,7 @@ module SolidusFriendlyPromotions
     # either come from assigned product group or are assingned directly to
     # the rule.
     class Product < PromotionRule
-      include OrderLevelRule
+      include LineItemApplicableOrderRule
 
       has_many :products_promotion_rules,
         dependent: :destroy,
@@ -24,19 +24,10 @@ module SolidusFriendlyPromotions
       validates :preferred_match_policy, inclusion: {in: MATCH_POLICIES}
 
       preference :match_policy, :string, default: MATCH_POLICIES.first
-      preference :line_item_applicable, :boolean, default: true
 
       # scope/association that is used to test eligibility
       def eligible_products
         products
-      end
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order) || preferred_line_item_applicable && promotable.is_a?(Spree::LineItem)
-      end
-
-      def eligible?(promotable)
-        send("#{promotable.class.name.demodulize.underscore}_eligible?", promotable)
       end
 
       def order_eligible?(order)

--- a/app/models/solidus_friendly_promotions/rules/shipment_level_rule.rb
+++ b/app/models/solidus_friendly_promotions/rules/shipment_level_rule.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module Rules
+    module ShipmentLevelRule
+      def applicable?(promotable)
+        promotable.is_a?(Spree::Shipment)
+      end
+
+      def level
+        :shipment
+      end
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/rules/shipping_method.rb
+++ b/app/models/solidus_friendly_promotions/rules/shipping_method.rb
@@ -3,6 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class ShippingMethod < PromotionRule
+      include ShipmentLevelRule
+
       preference :shipping_method_ids, type: :array, default: []
 
       def applicable?(promotable)
@@ -11,10 +13,6 @@ module SolidusFriendlyPromotions
 
       def eligible?(promotable)
         promotable.shipping_method&.id&.in?(preferred_shipping_method_ids.map(&:to_i))
-      end
-
-      def updateable?
-        true
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/rules/store.rb
+++ b/app/models/solidus_friendly_promotions/rules/store.rb
@@ -3,6 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class Store < PromotionRule
+      include OrderLevelRule
+
       has_many :promotion_rules_stores, class_name: "SolidusFriendlyPromotions::PromotionRulesStore",
         foreign_key: :promotion_rule_id,
         dependent: :destroy
@@ -10,10 +12,6 @@ module SolidusFriendlyPromotions
 
       def preload_relations
         [:stores]
-      end
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
       end
 
       def eligible?(order, _options = {})

--- a/app/models/solidus_friendly_promotions/rules/taxon.rb
+++ b/app/models/solidus_friendly_promotions/rules/taxon.rb
@@ -3,6 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class Taxon < PromotionRule
+      include OrderLevelRule
+
       has_many :promotion_rules_taxons, class_name: "SolidusFriendlyPromotions::PromotionRulesTaxon", foreign_key: :promotion_rule_id,
         dependent: :destroy
       has_many :taxons, through: :promotion_rules_taxons, class_name: "Spree::Taxon"
@@ -16,9 +18,6 @@ module SolidusFriendlyPromotions
       validates :preferred_match_policy, inclusion: {in: MATCH_POLICIES}
 
       preference :match_policy, :string, default: MATCH_POLICIES.first
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
 
       def eligible?(order, _options = {})
         order_taxons = taxons_in_order(order)

--- a/app/models/solidus_friendly_promotions/rules/user.rb
+++ b/app/models/solidus_friendly_promotions/rules/user.rb
@@ -3,6 +3,8 @@
 module SolidusFriendlyPromotions
   module Rules
     class User < PromotionRule
+      include OrderLevelRule
+
       has_many :promotion_rules_users,
         class_name: "SolidusFriendlyPromotions::PromotionRulesUser",
         foreign_key: :promotion_rule_id,
@@ -11,10 +13,6 @@ module SolidusFriendlyPromotions
 
       def preload_relations
         [:users]
-      end
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
       end
 
       def eligible?(order, _options = {})

--- a/app/models/solidus_friendly_promotions/rules/user_logged_in.rb
+++ b/app/models/solidus_friendly_promotions/rules/user_logged_in.rb
@@ -3,9 +3,7 @@
 module SolidusFriendlyPromotions
   module Rules
     class UserLoggedIn < PromotionRule
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
+      include OrderLevelRule
 
       def eligible?(order, _options = {})
         if order.user.blank?

--- a/app/models/solidus_friendly_promotions/rules/user_role.rb
+++ b/app/models/solidus_friendly_promotions/rules/user_role.rb
@@ -3,14 +3,12 @@
 module SolidusFriendlyPromotions
   module Rules
     class UserRole < PromotionRule
+      include OrderLevelRule
+
       preference :role_ids, :array, default: []
 
       MATCH_POLICIES = %w[any all].freeze
       preference :match_policy, default: MATCH_POLICIES.first
-
-      def applicable?(promotable)
-        promotable.is_a?(Spree::Order)
-      end
 
       def eligible?(order, _options = {})
         return false unless order.user

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/_promotion_rule.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/_promotion_rule.html.erb
@@ -2,18 +2,16 @@
 <div class="promotion_rule promotion-block" id="<%= dom_id promotion_rule %>">
   <%= form_with model: promotion_rule, scope: :promotion_rule, url: solidus_friendly_promotions.admin_promotion_promotion_rule_path(@promotion, promotion_rule), method: :patch do |form| %>
     <h6 class='promotion-title'><%= promotion_rule.class.model_name.human %></h6>
-    <% if  can?(:destroy, promotion_rule) %>
+    <% if can?(:destroy, promotion_rule) && promotion_rule.level == level %>
       <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_rule_path(@promotion, promotion_rule), method: :delete, class: 'delete' %>
     <% end %>
-    <p>
-      <%= promotion_rule.class.human_attribute_name(:description) %>
-    </p>
+
     <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
     <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
     <%= render partial: "spree/shared/error_messages", locals: { target: promotion_rule } %>
-    <%= render promotion_rule, promotion_rule: promotion_rule, param_prefix: "promotion_rule", form: form %>
+    <%= render promotion_rule, promotion_rule: promotion_rule, param_prefix: "promotion_rule", form: form, context: level %>
 
-    <% if promotion_rule.updateable? %>
+    <% if promotion_rule.updateable? && promotion_rule.level == level %>
       <div class="row">
         <div class="col-12">
           <%= form.submit(t(:update, scope: [:solidus_friendly_promotions, :crud]), class: "btn btn-secondary float-right") %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_line_item_option_value.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_line_item_option_value.html.erb
@@ -1,3 +1,4 @@
+
 <div class="field promo-rule-option-values">
   <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
   <div class="row">

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_option_value.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_option_value.html.erb
@@ -1,21 +1,60 @@
-<div class="field promo-rule-option-values">
-  <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
-  <div class="row">
-    <div class="col-6"><%= label_tag nil, Spree::Product.model_name.human %></div>
-    <div class="col-6"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
-  </div>
+<% context = local_assigns[:context] || :order %>
 
-  <div class="field">
-    <div data-controller="product-option-values">
-      <template data-product-option-values-target="template">
-        <%= render "solidus_friendly_promotions/admin/promotion_rules/rules/line_item_option_value/option_value_fields", product_option_values: [nil, []], form: form %>
-      </template>
-      <% form.object.preferred_eligible_values.each do |product_option_values| %>
-        <%= render "solidus_friendly_promotions/admin/promotion_rules/rules/line_item_option_value/option_value_fields", product_option_values: product_option_values, form: form %>
-      <% end %>
-      <div class="mb-3" data-product-option-values-target="links">
-        <%= link_to "Add Row", "#", class: "btn btn-outline-primary", data: { action: "click->product-option-values#add_row" } %>
+<% if context == :order %>
+  <div class="field promo-rule-option-values">
+    <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
+    <div class="row">
+      <div class="col-6"><%= label_tag nil, Spree::Product.model_name.human %></div>
+      <div class="col-6"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
+    </div>
+
+    <div class="field">
+      <div data-controller="product-option-values">
+        <template data-product-option-values-target="template">
+          <%= render "solidus_friendly_promotions/admin/promotion_rules/rules/line_item_option_value/option_value_fields", product_option_values: [nil, []], form: form %>
+        </template>
+        <% form.object.preferred_eligible_values.each do |product_option_values| %>
+          <%= render "solidus_friendly_promotions/admin/promotion_rules/rules/line_item_option_value/option_value_fields", product_option_values: product_option_values, form: form %>
+        <% end %>
+        <div class="mb-3" data-product-option-values-target="links">
+          <%= link_to "Add Row", "#", class: "btn btn-outline-primary", data: { action: "click->product-option-values#add_row" } %>
+        </div>
       </div>
     </div>
+
+    <div class="field">
+      <%= form.label :preferred_line_item_applicable do %>
+        <%= form.check_box :preferred_line_item_applicable %>
+        <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% else %>
+  <p>
+    <%= SolidusFriendlyPromotions::Rules::LineItemOptionValue.human_attribute_name(:description) %>
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>
+          <%= Spree::Product.model_name.human %>
+        </th>
+        <th>
+          <%= Spree::OptionValue.model_name.human(count: :other) %>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <% promotion_rule.preferred_eligible_values.each do |product_id, option_value_ids| %>
+        <tr>
+          <td>
+            <%= Spree::Product.find(product_id).name %>
+          </td>
+          <td>
+            <%= Spree::OptionValue.where(id: option_value_ids).map(&:name).join(", ") %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
@@ -15,4 +15,11 @@
     <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.product_rule.label', select: select).html_safe %>
     </label>
   </div>
+
+  <div class="field">
+    <%= form.label :preferred_line_item_applicable do %>
+      <%= form.check_box :preferred_line_item_applicable %>
+      <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
@@ -1,15 +1,18 @@
-<div class="row">
-  <div class="col-12">
-    <div class="field products_rule_products">
-      <%= label_tag "#{param_prefix}_product_ids_string", t('solidus_friendly_promotions.product_rule.choose_products') %>
-      <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
-    </div>
+<%= fields_for param_prefix, promotion_rule do |form| %>
+  <div class="field products_rule_products">
+    <%= form.label :product_ids_string, t('solidus_friendly_promotions.product_rule.choose_products') %>
+    <%= form.hidden_field :product_ids_string, value: promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
   </div>
-  <div class="col-12">
-    <div class="field">
-      <label>
-        <%= t('solidus_friendly_promotions.product_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map{|s| [t("solidus_friendly_promotions.product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product custom-select'})).html_safe %>
-      </label>
-    </div>
+
+  <div class="field">
+    <%
+      match_policy_options = options_for_select(
+        SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.product_rule.match_#{s}"),s] },
+        promotion_rule.preferred_match_policy
+      )
+    %>
+    <% select = form.select :preferred_match_policy, match_policy_options %>
+    <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.product_rule.label', select: select).html_safe %>
+    </label>
   </div>
-</div>
+<% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
@@ -1,25 +1,44 @@
-<%= fields_for param_prefix, promotion_rule do |form| %>
-  <div class="field products_rule_products">
-    <%= form.label :product_ids_string, t('solidus_friendly_promotions.product_rule.choose_products') %>
-    <%= form.hidden_field :product_ids_string, value: promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
-  </div>
+<% context = local_assigns[:context] || :order %>
 
-  <div class="field">
-    <%
-      match_policy_options = options_for_select(
-        SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.product_rule.match_#{s}"),s] },
-        promotion_rule.preferred_match_policy
-      )
-    %>
-    <% select = form.select :preferred_match_policy, match_policy_options %>
-    <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.product_rule.label', select: select).html_safe %>
-    </label>
-  </div>
+<% if context == :order %>
+<p>
+  <%= promotion_rule.class.human_attribute_name(:description) %>
+</p>
+  <%= fields_for param_prefix, promotion_rule do |form| %>
+    <div class="field products_rule_products">
+      <%= form.label :product_ids_string, t('solidus_friendly_promotions.product_rule.choose_products') %>
+      <%= form.hidden_field :product_ids_string, value: promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
+    </div>
 
-  <div class="field">
-    <%= form.label :preferred_line_item_applicable do %>
-      <%= form.check_box :preferred_line_item_applicable %>
-      <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
+    <div class="field">
+      <%
+        match_policy_options = options_for_select(
+          SolidusFriendlyPromotions::Rules::Product::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.product_rule.match_#{s}"),s] },
+          promotion_rule.preferred_match_policy
+        )
+      %>
+      <% select = form.select :preferred_match_policy, match_policy_options %>
+      <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.product_rule.label', select: select).html_safe %>
+      </label>
+    </div>
+
+    <div class="field">
+      <%= form.label :preferred_line_item_applicable do %>
+        <%= form.check_box :preferred_line_item_applicable %>
+        <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p>
+    <% match_policy_translation_key = promotion_rule.preferred_match_policy == "none" ? :exclude : :include %>
+    <%= t(match_policy_translation_key, scope: [:solidus_friendly_promotions, :promotion_rules, :line_item_product, :match_policies]) %>
+  </p>
+  <ul>
+    <% promotion_rule.products.each do |product| %>
+      <li>
+        <%= product.name %>
+      </li>
     <% end %>
-  </div>
+  </ul>
 <% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
@@ -1,9 +1,44 @@
-<div class="field taxons_rule_taxons">
-  <%= label_tag "#{param_prefix}_taxon_ids_string", t('solidus_friendly_promotions.taxon_rule.choose_taxons') %>
-  <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth", id: 'product_taxon_ids' %>
-</div>
-<div class="field">
-  <label>
-    <%= t('solidus_friendly_promotions.taxon_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map{|s| [t("solidus_friendly_promotions.taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon custom-select'})).html_safe %>
-  </label>
-</div>
+<% context = local_assigns[:context] || :order %>
+
+<% if context == :order %>
+<p>
+  <%= promotion_rule.class.human_attribute_name(:description) %>
+</p>
+  <%= fields_for param_prefix, promotion_rule do |form| %>
+    <div class="field taxons_rule_taxons">
+      <%= form.label :taxon_ids_string, t('solidus_friendly_promotions.taxon_rule.choose_taxons') %>
+      <%= form.hidden_field :taxon_ids_string, value: promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth" %>
+    </div>
+
+    <div class="field">
+      <%
+        match_policy_options = options_for_select(
+          SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.taxon_rule.match_#{s}"),s] },
+          promotion_rule.preferred_match_policy
+        )
+      %>
+      <% select = form.select :preferred_match_policy, match_policy_options %>
+      <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.taxon_rule.label', select: select).html_safe %>
+      </label>
+    </div>
+
+    <div class="field">
+      <%= form.label :preferred_line_item_applicable do %>
+        <%= form.check_box :preferred_line_item_applicable %>
+        <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p>
+    <% match_policy_translation_key = promotion_rule.preferred_match_policy == "none" ? :exclude : :include %>
+    <%= t(match_policy_translation_key, scope: [:solidus_friendly_promotions, :promotion_rules, :line_item_taxon, :match_policies]) %>
+  </p>
+  <ul>
+    <% promotion_rule.taxons.each do |taxon| %>
+      <li>
+        <%= taxon.name %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
         description: Line Item has specified product with matching option value
       solidus_friendly_promotions/rules/product:
         description: Order includes specified product(s)
+        line_item_level_description: 'Line item matches the specified products:'
         preferred_line_item_applicable: Should also apply to line items
       solidus_friendly_promotions/rules/line_item_product:
         description: Line item matches specified product(s)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
         description: Only one use per user
       solidus_friendly_promotions/rules/option_value:
         description: Order includes specified product(s) with matching option value(s)
+        preferred_line_item_applicable: Should also apply to line items
       solidus_friendly_promotions/rules/line_item_option_value:
         description: Line Item has specified product with matching option value
       solidus_friendly_promotions/rules/product:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,7 @@ en:
         description: Available only to the specified stores
       solidus_friendly_promotions/rules/taxon:
         description: Order includes products with specified taxon(s)
+        preferred_line_item_applicable: Should also apply to line items
       solidus_friendly_promotions/rules/line_item_taxon:
         description: Line Item has product with specified taxon(s)
         preferred_match_policy: Match Policy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
         description: Line Item has specified product with matching option value
       solidus_friendly_promotions/rules/product:
         description: Order includes specified product(s)
+        preferred_line_item_applicable: Should also apply to line items
       solidus_friendly_promotions/rules/line_item_product:
         description: Line item matches specified product(s)
         preferred_match_policy: Match Policy

--- a/spec/models/solidus_friendly_promotions/rules/option_value_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/option_value_spec.rb
@@ -14,28 +14,38 @@ RSpec.describe SolidusFriendlyPromotions::Rules::OptionValue do
     end
   end
 
-  describe "#applicable?" do
-    subject { rule.applicable?(promotable) }
-
-    context "when promotable is an order" do
-      let(:promotable) { Spree::Order.new }
-
-      it { is_expected.to be true }
-    end
-
-    context "when promotable is not an order" do
-      let(:promotable) { Spree::LineItem.new }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe "#eligible?" do
+  describe "#eligible?(order)" do
     subject { rule.eligible?(promotable) }
 
     let(:variant) { create :variant }
     let(:line_item) { create :line_item, variant: variant }
     let(:promotable) { line_item.order }
+
+    context "when there are any applicable line items" do
+      before do
+        rule.preferred_eligible_values = {line_item.product.id => [
+          line_item.variant.option_values.pick(:id)
+        ]}
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when there are no applicable line items" do
+      before do
+        rule.preferred_eligible_values = {99 => [99]}
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#eligible?(line_item)" do
+    subject { rule.eligible?(promotable) }
+
+    let(:variant) { create :variant }
+    let(:line_item) { create :line_item, variant: variant }
+    let(:promotable) { line_item }
 
     context "when there are any applicable line items" do
       before do


### PR DESCRIPTION
This PR accounts for the fact that in many, many cases, when admins enter an order-level rule that restricts a promotion to only certain products, taxons, or option values, they want these rules to apply at the line item level as well. We could model this before by adding a line item level rule with the same configuration, but that's really a footgun (what if admins accidentally update the order level rule, but not the line item level rule?). It also clutters the interface with a lot of form. 

In case the rule is not only applicable to orders, but also to line items, an informative panel appears in lieu of a form next to the line item rule. 

Here's an example: 

![grafik](https://github.com/friendlycart/solidus_friendly_promotions/assets/703401/a00c6798-5b51-48f1-b5d7-fc341a1bc324)
