### PR TITLE
Add Promotion Migrator

### DIFF
--- a/lib/solidus_friendly_promotions/promotion_map.rb
+++ b/lib/solidus_friendly_promotions/promotion_map.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  PROMOTION_MAP = {
+    rules: {
+      Spree::Promotion::Rules::ItemTotal =>
+        SolidusFriendlyPromotions::Rules::ItemTotal,
+      Spree::Promotion::Rules::Product =>
+        SolidusFriendlyPromotions::Rules::Product,
+      Spree::Promotion::Rules::User =>
+        SolidusFriendlyPromotions::Rules::User,
+      Spree::Promotion::Rules::FirstOrder =>
+        SolidusFriendlyPromotions::Rules::FirstOrder,
+      Spree::Promotion::Rules::UserLoggedIn =>
+        SolidusFriendlyPromotions::Rules::UserLoggedIn,
+      Spree::Promotion::Rules::OneUsePerUser =>
+        SolidusFriendlyPromotions::Rules::OneUsePerUser,
+      Spree::Promotion::Rules::Taxon =>
+        SolidusFriendlyPromotions::Rules::LineItemTaxon,
+      Spree::Promotion::Rules::NthOrder =>
+        SolidusFriendlyPromotions::Rules::NthOrder,
+      Spree::Promotion::Rules::OptionValue =>
+        SolidusFriendlyPromotions::Rules::OptionValue,
+      Spree::Promotion::Rules::FirstRepeatPurchaseSince =>
+        SolidusFriendlyPromotions::Rules::FirstRepeatPurchaseSince,
+      Spree::Promotion::Rules::UserRole =>
+        SolidusFriendlyPromotions::Rules::UserRole,
+      Spree::Promotion::Rules::Store =>
+        SolidusFriendlyPromotions::Rules::Store
+    },
+    actions: {
+      Spree::Promotion::Actions::CreateAdjustment => -> (old_action){
+        calculator = case old_action.calculator
+        when Spree::Calculator::FlatRate
+          SolidusFriendlyPromotions::Calculators::DistributedAmount.new(preferences: old_action.calculator.preferences)
+        when Spree::Calculator::FlatPercentItemTotal
+          SolidusFriendlyPromotions::Calculators::Percent.new(preferred_percent: old_action.calculator.preferred_flat_percent)
+        end
+
+        SolidusFriendlyPromotions::Actions::AdjustLineItem.new(
+          calculator: calculator
+        )
+      },
+      Spree::Promotion::Actions::CreateItemAdjustments => ->(old_action) {
+        preferences = old_action.calculator.preferences
+        calculator = case old_action.calculator
+        when Spree::Calculator::FlatRate
+          SolidusFriendlyPromotions::Calculators::FlatRate.new(preferences: preferences)
+        when Spree::Calculator::PercentOnLineItem
+          SolidusFriendlyPromotions::Calculators::Percent.new(preferences: preferences)
+        when Spree::Calculator::FlexiRate
+          SolidusFriendlyPromotions::Calculators::FlexiRate.new(preferences: preferences)
+        when Spree::Calculator::DistributedAmount
+          SolidusFriendlyPromotions::Calculators::DistributedAmount.new(preferences: preferences)
+        when Spree::Calculator::TieredFlatRate
+          SolidusFriendlyPromotions::Calculators::TieredFlatRate.new(preferences: preferences)
+        when Spree::Calculator::TieredPercent
+          SolidusFriendlyPromotions::Calculators::TieredPercent.new(preferences: preferences)
+        end
+
+        SolidusFriendlyPromotions::Actions::AdjustLineItem.new(
+          calculator: calculator
+        )
+      },
+      Spree::Promotion::Actions::CreateQuantityAdjustments => nil,
+      Spree::Promotion::Actions::FreeShipping => ->(old_action) {
+        SolidusFriendlyPromotions::Actions::AdjustShipment.new(
+          calculator: SolidusFriendlyPromotions::Calculators::Percent.new(
+            preferred_percent: 100
+          )
+        )
+      }
+    }
+  }
+end

--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class PromotionMigrator
+    PROMOTION_IGNORED_ATTRIBUTES = ["id", "type"]
+
+    attr_reader :promotion_map
+
+    def initialize(promotion_map)
+      @promotion_map = promotion_map
+    end
+
+    def call
+      SolidusFriendlyPromotions::Promotion.destroy_all
+      Spree::Promotion.all.each do |promotion|
+        new_promotion = copy_promotion(promotion)
+        new_promotion.rules = promotion.rules.flat_map do |old_promotion_rule|
+          generate_new_promotion_rules(old_promotion_rule)
+        end
+        new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
+          generate_new_promotion_actions(old_promotion_action)
+        end
+        new_promotion.save!
+      end
+    end
+
+    private
+
+    def copy_promotion(old_promotion)
+      SolidusFriendlyPromotions::Promotion.new(
+        old_promotion.attributes.except(*PROMOTION_IGNORED_ATTRIBUTES)
+      )
+    end
+
+    def generate_new_promotion_actions(old_promotion_action)
+      promo_action_config = promotion_map[:actions][old_promotion_action.class]
+      if promo_action_config.nil?
+        puts("#{old_promotion_action.class} is not supported")
+        return []
+      end
+      promo_action_config.call(old_promotion_action)
+    end
+
+    def generate_new_promotion_rules(old_promotion_rule)
+      new_promo_rule_class = promotion_map[:rules][old_promotion_rule.class]
+      if new_promo_rule_class.nil?
+        puts("#{old_promotion_rule.class} is not supported")
+        []
+      elsif new_promo_rule_class.respond_to?(:call)
+        new_promo_rule_class.call(old_promotion_rule)
+      else
+        new_rule = new_promo_rule_class.new(old_promotion_rule.attributes.except(*PROMOTION_IGNORED_ATTRIBUTES))
+        new_rule.preload_relations.each do |relation|
+          new_rule.send("#{relation}=", old_promotion_rule.send(relation))
+        end
+        [new_rule]
+      end
+    end
+  end
+end

--- a/lib/tasks/solidus_friendly_promotions/migrate_existing_promotions.rake
+++ b/lib/tasks/solidus_friendly_promotions/migrate_existing_promotions.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "solidus_friendly_promotions/promotion_migrator"
+
+namespace :solidus_friendly_promotions do
+  desc "Migrate Spree Promotions to Friendly Promotions using a map"
+  task migrate_existing_promotions: :environment do
+    require "solidus_friendly_promotions/promotion_map"
+
+    SolidusFriendlyPromotions::PromotionMigrator.new(SolidusFriendlyPromotions::PROMOTION_MAP).call
+  end
+end


### PR DESCRIPTION
This adds a promotion migrator that generates SolidusFriendlyPromotion objects from existing Spree::Promotion objects.

Care has been taken that this can be used in host applications.