### PR TITLE
Transparently replace promotion adjustments

### DIFF
--- a/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
+++ b/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
@@ -4,10 +4,15 @@ module SolidusFriendlyPromotions
   module AdjustmentDecorator
     def self.prepended(base)
       base.scope :friendly_promotion, -> { where(source_type: "SolidusFriendlyPromotions::PromotionAction") }
+      base.scope :promotion, -> { where(source_type: ["SolidusFriendlyPromotions::PromotionAction", "Spree::PromotionAction"]) }
     end
 
     def friendly_promotion?
       source_type == "SolidusFriendlyPromotions::PromotionAction"
+    end
+
+    def promotion?
+      super || source_type == "SolidusFriendlyPromotions::PromotionAction"
     end
     Spree::Adjustment.prepend self
   end

--- a/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
+++ b/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
@@ -14,6 +14,13 @@ module SolidusFriendlyPromotions
     def promotion?
       super || source_type == "SolidusFriendlyPromotions::PromotionAction"
     end
+
+    private
+
+    def require_promotion_code?
+      !friendly_promotion? && super
+    end
+
     Spree::Adjustment.prepend self
   end
 end

--- a/app/decorators/models/solidus_friendly_promotions/order_decorator.rb
+++ b/app/decorators/models/solidus_friendly_promotions/order_decorator.rb
@@ -17,8 +17,7 @@ module SolidusFriendlyPromotions
         recalculate
         errors.add(:base, I18n.t("solidus_friendly_promotions.promotion_total_changed_before_complete"))
       end
-
-      super
+      errors.empty?
     end
 
     def discountable_item_total

--- a/app/models/solidus_friendly_promotions/order_discounter.rb
+++ b/app/models/solidus_friendly_promotions/order_discounter.rb
@@ -44,13 +44,13 @@ module SolidusFriendlyPromotions
     # @param [Array<SolidusFriendlyPromotions::ItemDiscount>] item_discounts a list of calculated discounts for an item
     # @return [void]
     def update_adjustments(item, item_discounts)
-      promotion_adjustments = item.adjustments.select(&:friendly_promotion?)
+      promotion_adjustments = item.adjustments.select(&:promotion?)
 
       active_adjustments = item_discounts.map do |item_discount|
         update_adjustment(item, item_discount)
       end
       item.update(promo_total: active_adjustments.sum(&:amount))
-      # Remove any tax adjustments tied to rates which no longer match.
+      # Remove any tax adjustments tied to promotion actions which no longer match.
       unmatched_adjustments = promotion_adjustments - active_adjustments
 
       item.adjustments.destroy(unmatched_adjustments)

--- a/spec/models/solidus_friendly_promotions/order_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/order_discounter_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe SolidusFriendlyPromotions::OrderDiscounter, type: :model do
             subject.call
           }.to change { adjustable.adjustments.length }.by(0)
         end
+
+        context "for an line item that has an adjustment from the old promotion system" do
+          let(:old_promotion_action) { create(:promotion, :with_adjustable_action, apply_automatically: false).actions.first }
+          let!(:adjustment) { create(:adjustment, source: old_promotion_action, adjustable: line_item) }
+
+          it "removes the old adjustment from the line item" do
+            adjustable.reload
+            expect {
+              subject.call
+            }.to change { adjustable.reload.adjustments.length }.by(-1)
+          end
+        end
       end
     end
 

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Spree::Adjustment do
+  describe ".promotion" do
+    let(:spree_promotion_action) { create(:promotion, :with_action).actions.first }
+    let!(:spree_promotion_action_adjustment) { create(:adjustment, source: spree_promotion_action) }
+    let(:friendly_promotion_action) { create(:friendly_promotion, :with_adjustable_action).actions.first }
+    let!(:friendly_promotion_action_adjustment) { create(:adjustment, source: friendly_promotion_action) }
+    let(:tax_rate) { create(:tax_rate) }
+    let!(:tax_adjustment) { create(:adjustment, source: tax_rate) }
+
+    subject { described_class.promotion }
+
+    it { is_expected.to contain_exactly(friendly_promotion_action_adjustment, spree_promotion_action_adjustment) }
+  end
+
+  describe ".friendly_promotion" do
+    let(:spree_promotion_action) { create(:promotion, :with_action).actions.first }
+    let!(:spree_promotion_action_adjustment) { create(:adjustment, source: spree_promotion_action) }
+    let(:friendly_promotion_action) { create(:friendly_promotion, :with_adjustable_action).actions.first }
+    let!(:friendly_promotion_action_adjustment) { create(:adjustment, source: friendly_promotion_action) }
+    let(:tax_rate) { create(:tax_rate) }
+    let!(:tax_adjustment) { create(:adjustment, source: tax_rate) }
+
+    subject { described_class.friendly_promotion }
+
+    it { is_expected.to contain_exactly(friendly_promotion_action_adjustment) }
+  end
+
+  describe "#promotion?" do
+    let(:source) { create(:friendly_promotion, :with_adjustable_action).actions.first }
+    let!(:adjustment) { build(:adjustment, source: source) }
+
+    subject { adjustment.promotion? }
+
+    it { is_expected.to be true }
+
+    context "with a Spree Promotion Action source" do
+      let(:source) { create(:promotion, :with_action).actions.first }
+
+      it { is_expected.to be true }
+    end
+
+    context "with a Tax Rate source" do
+      let(:source) { create(:tax_rate) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#friendly_promotion?" do
+    let(:source) { create(:friendly_promotion, :with_adjustable_action).actions.first }
+    let!(:adjustment) { build(:adjustment, source: source) }
+
+    subject { adjustment.friendly_promotion? }
+
+    it { is_expected.to be true }
+
+    context "with a Spree Promotion Action source" do
+      let(:source) { create(:promotion, :with_action).actions.first }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a Tax Rate source" do
+      let(:source) { create(:tax_rate) }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
This is to support the migration of existing stores. After having migrated the promotion configuration, you can flip the switch, and old promotion system adjustments will be replaced by new promotion system adjustments.