### PR TITLE
Fix spec warning in promotion rules spec

### DIFF
--- a/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionRule do
 
   it "forces developer to implement eligible? method" do
     expect { bad_test_rule_class.new.eligible?("promotable") }.to raise_error NotImplementedError
-    expect { test_rule_class.new.eligible?("promotable") }.not_to raise_error NotImplementedError
+    expect { test_rule_class.new.eligible?("promotable") }.not_to raise_error
   end
 
   it "validates unique rules for a promotion" do


### PR DESCRIPTION
Removes a (legitimate) warning from our spec runs.