### PR TITLE
Add back references to promotions and actions

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -4,6 +4,7 @@ module SolidusFriendlyPromotions
   class Promotion < Spree::Base
     belongs_to :category, class_name: "SolidusFriendlyPromotions::PromotionCategory",
       foreign_key: :promotion_category_id, optional: true
+    belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true
     has_many :rules, class_name: "SolidusFriendlyPromotions::PromotionRule", dependent: :destroy
     has_many :actions, class_name: "SolidusFriendlyPromotions::PromotionAction", dependent: :nullify
     has_many :codes, class_name: "SolidusFriendlyPromotions::PromotionCode", dependent: :destroy

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -14,6 +14,7 @@ module SolidusFriendlyPromotions
     include Spree::AdjustmentSource
 
     belongs_to :promotion, inverse_of: :actions
+    belongs_to :original_promotion_action, class_name: "Spree::PromotionAction", optional: true
     has_many :adjustments, class_name: "Spree::Adjustment", as: :source
 
     scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }

--- a/db/migrate/20231013181921_add_original_promotion_ids.rb
+++ b/db/migrate/20231013181921_add_original_promotion_ids.rb
@@ -1,0 +1,6 @@
+class AddOriginalPromotionIds < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :friendly_promotions, :original_promotion, type: :integer, index: { name: :index_original_promotion_id }, foreign_key: { to_table: :spree_promotions }
+    add_reference :friendly_promotion_actions, :original_promotion_action, type: :integer, index: { name: :index_original_promotion_action_id }, foreign_key: { to_table: :spree_promotion_actions }
+  end
+end

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -41,4 +41,22 @@ RSpec.describe SolidusFriendlyPromotions::PromotionAction do
       )
     end
   end
+
+  describe ".original_promotion_action" do
+    let(:spree_promotion) { create :promotion, :with_adjustable_action }
+    let(:spree_promotion_action) { spree_promotion.actions.first }
+    let(:friendly_promotion) { create :friendly_promotion, :with_adjustable_action }
+    let(:friendly_promotion_action) { friendly_promotion.actions.first }
+
+    subject { friendly_promotion_action.original_promotion_action }
+
+    it "can be migrated from spree" do
+      friendly_promotion_action.original_promotion_action = spree_promotion_action
+      expect(subject).to eq(spree_promotion_action)
+    end
+
+    it "is ok to be new" do
+      expect(subject).to be_nil
+    end
+  end
 end

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   describe "#inactive" do
     let(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
 
-    it "is not exipired" do
+    it "is not expired" do
       expect(promotion).not_to be_inactive
     end
 
@@ -577,6 +577,22 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
 
     context "when the user has not used this promo" do
       it { is_expected.to be false }
+    end
+  end
+
+  describe ".original_promotion" do
+    let(:spree_promotion) { create :promotion, :with_adjustable_action }
+    let(:friendly_promotion) { create :friendly_promotion, :with_adjustable_action }
+
+    subject { friendly_promotion.original_promotion }
+
+    it "can be migrated from spree" do
+      friendly_promotion.original_promotion = spree_promotion
+      expect(subject).to eq(spree_promotion)
+    end
+
+    it "is ok to be new" do
+      expect(subject).to be_nil
     end
   end
 end


### PR DESCRIPTION
During and after migrating promotions from the existing system, it would be nice for troubleshooting and auditing to be able to determine exactly which promotion and action they came from.

https://github.com/friendlycart/solidus_friendly_promotions/issues/33
