### PR TITLE
Migrator: Migrate promotion codes and promotion code batches

### DIFF
--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -28,6 +28,11 @@ module SolidusFriendlyPromotions
         new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
           generate_new_promotion_actions(old_promotion_action)
         end
+        new_promotion.codes = promotion.codes.map do |old_code|
+          SolidusFriendlyPromotions::PromotionCode.new(
+            old_code.attributes
+          )
+        end
         new_promotion.save!
       end
     end

--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -28,9 +28,18 @@ module SolidusFriendlyPromotions
         new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
           generate_new_promotion_actions(old_promotion_action)
         end
-        new_promotion.codes = promotion.codes.map do |old_code|
-          SolidusFriendlyPromotions::PromotionCode.new(
-            old_code.attributes
+        new_promotion.save!
+        promotion.promotion_code_batches.each do |old_pcb|
+          new_promotion.code_batches.detect { |pcb| old_pcb.base_code == pcb.base_code } || new_promotion.code_batches.build(
+            number_of_codes: old_pcb.number_of_codes,
+            base_code: old_pcb.base_code
+          )
+        end
+        promotion.codes.each do |old_code|
+          pcb = new_promotion.code_batches.detect { |pcb| pcb.base_code == old_code.promotion_code_batch&.base_code }
+          new_promotion.codes.build(
+            promotion_code_batch: pcb,
+            value: old_code.value
           )
         end
         new_promotion.save!

--- a/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe SolidusFriendlyPromotions::PromotionMigrator do
       expect(promotion_category.name).to eq("Sith")
     end
   end
+
+  context "when an existing promotion has promotion codes" do
+    let(:spree_promotion) { create(:promotion, code: "ANDOR LIFE") }
+
+    it "creates codes for the new promotion, identical to the previous one" do
+      expect { subject }.to change { SolidusFriendlyPromotions::PromotionCode.count }.by(1)
+      promotion_code = SolidusFriendlyPromotions::PromotionCode.first
+      expect(promotion_code.value).to eq("andor life")
+    end
+  end
 end

--- a/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe SolidusFriendlyPromotions::PromotionMigrator do
       expect(promotion_code.value).to eq("andor life")
     end
   end
+
+  context "when an existing promotion has promotion codes with promotion code batches" do
+    let!(:promotion_code_batch) do
+      Spree::PromotionCodeBatch.new(promotion: spree_promotion, base_code: "DISNEY4LIFE", number_of_codes: 1)
+    end
+
+    let!(:promotion_code) { create(:promotion_code, promotion: spree_promotion, promotion_code_batch: promotion_code_batch) }
+    let(:spree_promotion) { create(:promotion) }
+
+    it "creates the promotion code batch copy" do
+      expect { subject }.to change { SolidusFriendlyPromotions::PromotionCodeBatch.count }.by(1)
+      promotion_code_batch = SolidusFriendlyPromotions::PromotionCodeBatch.first
+      expect(promotion_code_batch.base_code).to eq("DISNEY4LIFE")
+    end
+  end
 end


### PR DESCRIPTION
This migrates the promotion codes and promotion code batches from the legacy promotion system to the current promotion system.

Fixes #43 