### PR TITLE
Migrator: Store original promotion and promotion action

### DIFF
--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -26,7 +26,9 @@ module SolidusFriendlyPromotions
           generate_new_promotion_rules(old_promotion_rule)
         end
         new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
-          generate_new_promotion_actions(old_promotion_action)
+          generate_new_promotion_actions(old_promotion_action).tap do |new_promotion_action|
+            new_promotion_action.original_promotion_action = old_promotion_action
+          end
         end
         new_promotion.save!
       end
@@ -36,7 +38,10 @@ module SolidusFriendlyPromotions
 
     def copy_promotion(old_promotion)
       SolidusFriendlyPromotions::Promotion.new(
-        old_promotion.attributes.except(*PROMOTION_IGNORED_ATTRIBUTES).merge(customer_label: old_promotion.name)
+        old_promotion.attributes.except(*PROMOTION_IGNORED_ATTRIBUTES).merge(
+          customer_label: old_promotion.name,
+          original_promotion: old_promotion
+        )
       )
     end
 

--- a/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe SolidusFriendlyPromotions::PromotionMigrator do
 
   subject(:promotion_migrator) { SolidusFriendlyPromotions::PromotionMigrator.new(promotion_map).call }
 
+  it "stores original promotion and original promotion action" do
+    subject
+    expect(SolidusFriendlyPromotions::Promotion.first.original_promotion).to eq(spree_promotion)
+    expect(SolidusFriendlyPromotions::PromotionAction.first.original_promotion_action).to eq(spree_promotion.promotion_actions.first)
+  end
+
   context "when an existing promotion has a promotion category" do
     let(:spree_promotion_category) { create(:promotion_category, name: "Sith") }
     let(:spree_promotion) { create(:promotion, promotion_category: spree_promotion_category) }


### PR DESCRIPTION
Now that we have associations for the original promotion and original promotion actions, we need to also store them when migrating.

Fixes #33 