### PR TITLE
Import eligiblity error messages from Solidus

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -49,7 +49,7 @@ module SolidusFriendlyPromotions
     end
 
     def eligibility_error_message(key, options = {})
-      I18n.t(key, **{scope: [:spree, :eligibility_errors, :messages]}.merge(options))
+      I18n.t(key, **{scope: [:solidus_friendly_promotions, :eligibility_errors, self.class.name.underscore]}.merge(options))
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,46 @@ en:
     hints:
       solidus_friendly_promotions/calculator:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
+    eligibility_errors:
+      solidus_friendly_promotions/rules/first_order:
+        not_first_order: This coupon code can only be applied to your first order.
+      solidus_friendly_promotions/rules/first_repeat_purchase_since:
+      solidus_friendly_promotions/rules/item_total:
+        item_total_doesnt_match_with_operator: This coupon code can't be applied to orders %{operator} %{amount}.
+        item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
+        item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
+      solidus_friendly_promotions/rules/discounted_item_total:
+        item_total_doesnt_match_with_operator: This coupon code can't be applied to orders %{operator} %{amount}.
+        item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
+        item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
+      solidus_friendly_promotions/rules/landing_page:
+      solidus_friendly_promotions/rules/nth_order:
+      solidus_friendly_promotions/rules/one_use_per_user:
+        no_user_specified: You need to login before applying this coupon code.
+        limit_once_per_user: This coupon code can only be used once per user.
+      solidus_friendly_promotions/rules/option_value:
+      solidus_friendly_promotions/rules/line_item_option_value:
+      solidus_friendly_promotions/rules/product:
+        has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
+        missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
+        no_applicable_products: You need to add an applicable product before applying this coupon code.
+      solidus_friendly_promotions/rules/line_item_product:
+        has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
+        missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
+        no_applicable_products: You need to add an applicable product before applying this coupon code.
+      solidus_friendly_promotions/rules/taxon:
+        has_excluded_taxon: Your cart contains a product from an excluded category that prevents this coupon code from being applied.
+        missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
+        no_matching_taxons: You need to add a product from an applicable category before applying this coupon code.
+      solidus_friendly_promotions/rules/line_item_taxon:
+        has_excluded_taxon: Your cart contains a product from an excluded category that prevents this coupon code from being applied.
+        missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
+        no_matching_taxons: You need to add a product from an applicable category before applying this coupon code.
+      solidus_friendly_promotions/rules/user:
+        no_user_specified: You need to login before applying this coupon code.
+      solidus_friendly_promotions/rules/user_logged_in:
+        no_user_specified: You need to login before applying this coupon code.
+      solidus_friendly_promotions/rules/user_role:
     product_rule:
       choose_products: Choose products
       label: Order must contain %{select} these products


### PR DESCRIPTION
We want to have all the relevant I18n content for promotions in this gem, under our namespace. This commit accomplishes that.