### PR TITLE
Fix: SolidusFriendlyPromotions, not Shipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In Solidus Core, Promotion adjustments get recalculated twice on every change to
 
 The design decision here is to make the code path easier to follow, and consequently to make it more performant ("Make it easy, then make it fast").
 
-`SolidusFriendlyShipping::Promotion` objects have rules and actions, just like `Spree::Promotion`. However, both rules and actions work slightly differently.
+`SolidusFriendlyPromotions::Promotion` objects have rules and actions, just like `Spree::Promotion`. However, both rules and actions work slightly differently.
 
 ### Promotion lanes
 

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_shipping_method.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_shipping_method.html.erb
@@ -2,7 +2,7 @@
   <%= promotion_rule.class.human_attribute_name(:description) %>
 </p>
 <div class="form-group">
-  <%= label_tag "#{param_prefix}_preferred_shipping_method_ids", SolidusFriendlyShipping::Rules::ShippingMethod.human_attribute_name(:preferred_shipping_method_ids) %>
+  <%= label_tag "#{param_prefix}_preferred_shipping_method_ids", SolidusFriendlyPromotions::Rules::ShippingMethod.human_attribute_name(:preferred_shipping_method_ids) %>
   <%= select_tag "#{param_prefix}[preferred_shipping_method_ids]",
     options_from_collection_for_select(
       Spree::ShippingMethod.all, :id, :name, promotion_rule.preferred_shipping_method_ids


### PR DESCRIPTION
This fixes two instances, one in the README, where we were using the wrong top-level constant.