### PR TITLE
Line Item Product Rule: Add error messaging

### DIFF
--- a/app/models/solidus_friendly_promotions/rules/line_item_product.rb
+++ b/app/models/solidus_friendly_promotions/rules/line_item_product.rb
@@ -19,11 +19,19 @@ module SolidusFriendlyPromotions
       preference :match_policy, :string, default: MATCH_POLICIES.first
 
       def eligible?(line_item, _options = {})
-        if inverse?
-          !product_ids.include?(line_item.variant.product_id)
-        else
-          product_ids.include?(line_item.variant.product_id)
+        order_includes_product = product_ids.include?(line_item.variant.product_id)
+        success = inverse? ? !order_includes_product : order_includes_product
+
+        unless success
+          message_code = inverse? ? :has_excluded_product : :no_applicable_products
+          eligibility_errors.add(
+            :base,
+            eligibility_error_message(message_code),
+            error_code: message_code
+          )
         end
+
+        success
       end
 
       def product_ids_string

--- a/spec/models/solidus_friendly_promotions/rules/line_item_product_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/line_item_product_spec.rb
@@ -24,12 +24,24 @@ RSpec.describe SolidusFriendlyPromotions::Rules::LineItemProduct, type: :model d
       let(:line_item) { rule_line_item }
 
       it { is_expected.to be_truthy }
+
+      it "has no error message" do
+        subject
+        expect(rule.eligibility_errors.full_messages).to be_empty
+      end
     end
 
     context "for product not in rule" do
       let(:line_item) { other_line_item }
 
       it { is_expected.to be_falsey }
+
+      it "has the right error message" do
+        subject
+        expect(rule.eligibility_errors.full_messages.first).to eq(
+          "You need to add an applicable product before applying this coupon code."
+        )
+      end
     end
 
     context "if match policy is inverse" do
@@ -39,12 +51,24 @@ RSpec.describe SolidusFriendlyPromotions::Rules::LineItemProduct, type: :model d
         let(:line_item) { rule_line_item }
 
         it { is_expected.to be_falsey }
+
+        it "has the right error message" do
+          subject
+          expect(rule.eligibility_errors.full_messages.first).to eq(
+            "Your cart contains a product that prevents this coupon code from being applied."
+          )
+        end
       end
 
       context "for product not in rule" do
         let(:line_item) { other_line_item }
 
         it { is_expected.to be_truthy }
+
+        it "has no error message" do
+          subject
+          expect(rule.eligibility_errors.full_messages).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
This adds the error messaging capability to the line item products rule. Consider that all errors are on the order level, and that they won't appear if other line items make them irrelevant.