### PR TITLE
Collect Eligibility Results

### DIFF
--- a/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
@@ -10,6 +10,10 @@ module SolidusFriendlyPromotions
       def available_calculators
         SolidusFriendlyPromotions.config.line_item_discount_calculators
       end
+
+      def level
+        :line_item
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
@@ -10,6 +10,10 @@ module SolidusFriendlyPromotions
       def available_calculators
         SolidusFriendlyPromotions.config.shipment_discount_calculators
       end
+
+      def level
+        :shipment
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
+++ b/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
@@ -29,7 +29,7 @@ module SolidusFriendlyPromotions
 
       def eligible_line_items(order)
         order.line_items.reject do |line_item|
-          SolidusFriendlyPromotions::PromotionEligibility.new(
+          SolidusFriendlyPromotions::PromotionsEligibility.new(
             promotable: line_item,
             possible_promotions: [calculable.promotion]
           ).call.empty?

--- a/app/models/solidus_friendly_promotions/eligibility_result.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_result.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  EligibilityResult = Struct.new(:item, :success, :code, :message, keyword_init: true)
+end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class EligibilityResults
+    attr_accessor :results_by_promotion
+    def initialize
+      @results_by_promotion = {}
+    end
+
+    def add(item:, rule:, success:, code:, message:)
+      results_by_promotion[rule.promotion] ||= {}
+      results_by_promotion[rule.promotion][rule] ||= []
+      results_by_promotion[rule.promotion][rule] << EligibilityResult.new(
+        item: item,
+        success: success,
+        code: code,
+        message: message
+      )
+    end
+
+    def for(promotion)
+      results_by_promotion[promotion]
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -21,5 +21,31 @@ module SolidusFriendlyPromotions
     def for(promotion)
       results_by_promotion[promotion]
     end
+
+    def success?(promotion)
+      results_for_promotion = self.for(promotion)
+      return true unless results_for_promotion
+      promotion.actions.any? do |action|
+        action.relevant_rules.all? do |rule|
+          results_for_promotion[rule].present? &&
+            results_for_promotion[rule].any?(&:success)
+        end
+      end
+    end
+
+    def errors_for(promotion)
+      results_for_promotion = self.for(promotion)
+      return [] unless results_for_promotion
+      results_for_promotion.map do |rule, results|
+        next if results.any?(&:success)
+        results.detect { |r| !r.success }&.message
+      end.compact
+    end
+
+    private
+
+    def item_results_eligible?(klass, resultset)
+      resultset[klass].nil? || resultset[klass].any? { |result| result.success }
+    end
   end
 end

--- a/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
@@ -15,7 +15,7 @@ module SolidusFriendlyPromotions
       order.reset_current_discounts
 
       SolidusFriendlyPromotions::Promotion.ordered_lanes.each do |lane, _index|
-        lane_promotions = PromotionEligibility.new(
+        lane_promotions = PromotionsEligibility.new(
           promotable: order,
           possible_promotions: promotions.select { |promotion| promotion.lane == lane }
         ).call

--- a/app/models/solidus_friendly_promotions/item_discounter.rb
+++ b/app/models/solidus_friendly_promotions/item_discounter.rb
@@ -2,16 +2,18 @@
 
 module SolidusFriendlyPromotions
   class ItemDiscounter
-    attr_reader :promotions
+    attr_reader :promotions, :eligibility_results
 
-    def initialize(promotions:)
+    def initialize(promotions:, eligibility_results: nil)
       @promotions = promotions
+      @eligibility_results = eligibility_results
     end
 
     def call(item)
       eligible_promotions = PromotionsEligibility.new(
         promotable: item,
-        possible_promotions: promotions
+        possible_promotions: promotions,
+        eligibility_results: eligibility_results
       ).call
 
       eligible_promotions.flat_map do |promotion|

--- a/app/models/solidus_friendly_promotions/item_discounter.rb
+++ b/app/models/solidus_friendly_promotions/item_discounter.rb
@@ -9,7 +9,7 @@ module SolidusFriendlyPromotions
     end
 
     def call(item)
-      eligible_promotions = PromotionEligibility.new(
+      eligible_promotions = PromotionsEligibility.new(
         promotable: item,
         possible_promotions: promotions
       ).call

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -58,6 +58,12 @@ module SolidusFriendlyPromotions
       raise NotImplementedError
     end
 
+    def relevant_rules
+      promotion.rules.select do |rule|
+        rule.level.in?([:order, level].uniq)
+      end
+    end
+
     def available_calculators
       raise NotImplementedError
     end

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -54,6 +54,10 @@ module SolidusFriendlyPromotions
       "solidus_friendly_promotions/admin/promotion_actions/actions/#{model_name.element}"
     end
 
+    def level
+      raise NotImplementedError
+    end
+
     def available_calculators
       raise NotImplementedError
     end

--- a/app/models/solidus_friendly_promotions/promotion_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotion_eligibility.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class PromotionEligibility
+    attr_reader :promotable, :promotion, :eligibility_results
+
+    def initialize(promotable:, promotion:, eligibility_results: nil)
+      @promotable = promotable
+      @promotion = promotion
+      @eligibility_results = eligibility_results
+    end
+
+    def call
+      applicable_rules = promotion.rules.select do |rule|
+        rule.applicable?(promotable)
+      end
+
+      applicable_rules.map do |applicable_rule|
+        eligible = applicable_rule.eligible?(promotable)
+
+        break [false] if !eligible && !eligibility_results
+
+        if eligibility_results
+          if applicable_rule.eligibility_errors.details[:base].first
+            code = applicable_rule.eligibility_errors.details[:base].first[:error_code]
+            message = applicable_rule.eligibility_errors.full_messages.first
+          end
+          eligibility_results.add(
+            item: promotable,
+            rule: applicable_rule,
+            success: eligible,
+            code: eligible ? nil : (code || :unknown_error),
+            message: eligible ? nil : (message || I18n.t(:unknown_error, scope: [:solidus_friendly_promotions, :eligibility_errors]))
+          )
+        end
+
+        eligible
+      end.all?
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/promotions_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotions_eligibility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusFriendlyPromotions
-  class PromotionEligibility
+  class PromotionsEligibility
     attr_reader :promotable, :possible_promotions
 
     def initialize(promotable:, possible_promotions:)

--- a/app/models/solidus_friendly_promotions/promotions_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotions_eligibility.rb
@@ -2,22 +2,17 @@
 
 module SolidusFriendlyPromotions
   class PromotionsEligibility
-    attr_reader :promotable, :possible_promotions
+    attr_reader :promotable, :possible_promotions, :eligibility_results
 
-    def initialize(promotable:, possible_promotions:)
+    def initialize(promotable:, possible_promotions:, eligibility_results: nil)
       @promotable = promotable
       @possible_promotions = possible_promotions
+      @eligibility_results = eligibility_results
     end
 
     def call
       possible_promotions.select do |candidate|
-        applicable_rules = candidate.rules.select do |rule|
-          rule.applicable?(promotable)
-        end
-
-        applicable_rules.all? do |applicable_rule|
-          applicable_rule.eligible?(promotable)
-        end
+        PromotionEligibility.new(promotable: promotable, promotion: candidate, eligibility_results: eligibility_results).call
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,17 @@ en:
     hints:
       solidus_friendly_promotions/calculator:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
+    coupon_code: Coupon code
     eligibility_errors:
+      already_applied: The coupon code has already been applied to this order
+      applied: The coupon code was successfully applied to your order.
+      expired: The coupon code is expired
+      max_usage: Coupon code usage limit exceeded
+      not_eligible: This coupon code is not eligible for this order
+      not_found: The coupon code you entered doesn't exist. Please try again.
+      not_present: The coupon code you are trying to remove is not present on this order.
+      removed: The coupon code was successfully removed from this order.
+      unknown_error: This coupon code could not be applied to the cart at this time.
       solidus_friendly_promotions/rules/first_order:
         not_first_order: This coupon code can only be applied to your first order.
       solidus_friendly_promotions/rules/first_repeat_purchase_since:

--- a/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
@@ -22,4 +22,20 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustLineItem do
 
     it { is_expected.to eq(:line_item) }
   end
+
+  describe "#relevant_rules" do
+    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
+    let(:action) { described_class.new(calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
+    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
+    let(:product) { create(:product) }
+    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
+    let(:ups) { create(:shipping_method) }
+    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
+
+    subject { action.relevant_rules }
+
+    it { is_expected.to contain_exactly(order_rule, line_item_rule) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustLineItem do
 
     it { is_expected.to eq("solidus_friendly_promotions/admin/promotion_actions/actions/adjust_line_item") }
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it { is_expected.to eq(:line_item) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
@@ -38,4 +38,20 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustShipment do
 
     it { is_expected.to eq(:shipment) }
   end
+
+  describe "#relevant_rules" do
+    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
+    let(:action) { described_class.new(calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
+    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
+    let(:product) { create(:product) }
+    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
+    let(:ups) { create(:shipping_method) }
+    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
+
+    subject { action.relevant_rules }
+
+    it { is_expected.to contain_exactly(order_rule, shipment_rule) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustShipment do
       it { is_expected.to be true }
     end
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it { is_expected.to eq(:shipment) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::EligibilityResult do
+  it { is_expected.to respond_to(:item) }
+  it { is_expected.to respond_to(:success) }
+  it { is_expected.to respond_to(:code) }
+  it { is_expected.to respond_to(:message) }
+end

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
+  subject(:eligibility_results) { described_class.new }
+
+  describe "#add" do
+    let(:promotion) { create(:friendly_promotion) }
+    let(:order) { create(:order, item_total: 100) }
+    let(:rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(promotion: promotion, preferred_amount: 101) }
+
+    it "can add an error result" do
+      result = rule.eligible?(order)
+
+      eligibility_results.add(
+        item: order,
+        rule: rule,
+        success: result,
+        code: rule.eligibility_errors.details[:base].first[:error_code],
+        message: rule.eligibility_errors.full_messages.first
+      )
+
+      expect(eligibility_results.for(promotion)).to eq({
+        rule => [
+          SolidusFriendlyPromotions::EligibilityResult.new(
+            item: order,
+            success: result,
+            code: rule.eligibility_errors.details[:base].first[:error_code],
+            message: rule.eligibility_errors.full_messages.first
+          )
+        ]
+      })
+    end
+  end
+end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -13,4 +13,146 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
       expect(subject).to eq(order)
     end
   end
+
+  describe "collecting eligibility results" do
+    let(:shirt) { create(:product, name: "Shirt") }
+    let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}]) }
+    let(:rules) { [product_rule] }
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, rules: rules, name: "20% off Shirts", apply_automatically: true) }
+    let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+    let(:discounter) { described_class.new(order, collect_eligibility_results: true) }
+
+    subject { discounter.call }
+
+    it "will collect eligibility results" do
+      subject
+
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
+    end
+
+    it "can tell us about success" do
+      subject
+      expect(discounter.eligibility_results.success?(promotion)).to be true
+    end
+
+    context "with two rules" do
+      let(:rules) { [product_rule, item_total_rule] }
+      let(:item_total_rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(preferred_amount: 2000) }
+
+      it "will collect eligibility results" do
+        subject
+
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.success).to be false
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.code).to eq :item_total_less_than_or_equal
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.message).to eq "This coupon code can't be applied to orders less than or equal to $2,000.00."
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.item).to eq(order)
+      end
+
+      it "can tell us about success" do
+        subject
+        expect(discounter.eligibility_results.success?(promotion)).to be false
+      end
+
+      it "has errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to eq([
+          "This coupon code can't be applied to orders less than or equal to $2,000.00."
+        ])
+      end
+    end
+
+    context "with an order with multiple line items and an item-level rule" do
+      let(:pants) { create(:product, name: "Pants") }
+      let(:order) do
+        create(
+          :order_with_line_items,
+          line_items_attributes: [{variant: shirt.master, quantity: 1}, {variant: pants.master, quantity: 1}]
+        )
+      end
+
+      let(:shirt_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [shirt]) }
+      let(:rules) { [shirt_product_rule] }
+
+      it "can tell us about success" do
+        subject
+        # This is successful, because one of the line item rules matches
+        expect(discounter.eligibility_results.success?(promotion)).to be true
+      end
+
+      it "has no errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to be_empty
+      end
+
+      context "with a second line item level rule" do
+        let(:hat) { create(:product) }
+        let(:hat_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [hat]) }
+        let(:rules) { [shirt_product_rule, hat_product_rule] }
+
+        it "can tell us about success" do
+          subject
+          expect(discounter.eligibility_results.success?(promotion)).to be false
+        end
+
+        it "has errors for this promo" do
+          subject
+          expect(discounter.eligibility_results.errors_for(promotion)).to eq([
+            "You need to add an applicable product before applying this coupon code."
+          ])
+        end
+      end
+    end
+
+    context "when the order must not contain a shirt" do
+      let(:no_shirt_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_match_policy: "none", preferred_line_item_applicable: false) }
+      let(:rules) { [no_shirt_rule] }
+
+      it "can tell us about success" do
+        subject
+        # This is successful, because the order has a shirt
+        expect(discounter.eligibility_results.success?(promotion)).to be false
+      end
+    end
+
+    context "with a promotion with a line-item level action and a shipment-level action where only one action succeeds" do
+      let(:usps) { create(:shipping_method) }
+      let(:ups_ground) { create(:shipping_method) }
+      let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}], shipping_method: ups_ground) }
+      let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+      let(:shipping_method_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [usps.id]) }
+      let(:ten_off_items) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
+      let(:ten_off_shipping) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
+      let(:shipping_action) { SolidusFriendlyPromotions::Actions::AdjustShipment.new(calculator: ten_off_shipping) }
+      let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items) }
+      let(:actions) { [shipping_action, line_item_action] }
+      let(:rules) { [product_rule, shipping_method_rule] }
+      let!(:promotion) { create(:friendly_promotion, actions: actions, rules: rules, name: "10% off Shirts and USPS Shipping", apply_automatically: true) }
+
+      it "can tell us about success" do
+        subject
+        expect(discounter.eligibility_results.success?(promotion)).to be true
+      end
+
+      it "can tell us about errors" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to eq(["This coupon code could not be applied to the cart at this time."])
+      end
+    end
+
+    context "with no rules" do
+      let(:rules) { [] }
+
+      it "has no errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -154,5 +154,27 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
         expect(discounter.eligibility_results.errors_for(promotion)).to be_empty
       end
     end
+
+    context "with an ineligible order-level rule" do
+      let(:mug) { create(:product) }
+      let(:order_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+      let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [mug]) }
+      let(:rules) { [order_rule, line_item_rule] }
+
+      it "can tell us about success" do
+        subject
+        expect(discounter.eligibility_results.success?(promotion)).to be false
+      end
+
+      it "can tell us about all the errors", :pending do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to eq(
+          [
+            "This coupon code could not be applied to the cart at this time.",
+            "You need to add an applicable product before applying this coupon code."
+          ]
+        )
+      end
+    end
   end
 end

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe SolidusFriendlyPromotions::PromotionAction do
       expect(subject).to be_nil
     end
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it "raises an error" do
+      expect { subject }.to raise_exception(NotImplementedError)
+    end
+  end
 end


### PR DESCRIPTION
This allows the friendly promotion to tell the calling code about the success or lack thereof when trying to apply a particular set of promotions. It's useful for implementing e.g. a future `Coupon` Promotion Handler that will only add a coupon to an order IF the order is eligible for that promotion.