### PR TITLE
Backport promotion code batch fix from Solidus

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_code/batch_builder.rb
+++ b/app/models/solidus_friendly_promotions/promotion_code/batch_builder.rb
@@ -33,7 +33,8 @@ module SolidusFriendlyPromotions
       private
 
       def generate_random_codes
-        created_codes = 0
+        created_codes = promotion_code_batch.promotion_codes.count
+
         batch_size = @options[:batch_size]
 
         while created_codes < number_of_codes
@@ -42,13 +43,15 @@ module SolidusFriendlyPromotions
           new_codes = Array.new(max_codes_to_generate) { generate_random_code }.uniq
           codes_for_current_batch = get_unique_codes(new_codes)
 
-          codes_for_current_batch.each do |value|
-            PromotionCode.create!(
+          codes_for_current_batch = codes_for_current_batch.map do |value|
+            SolidusFriendlyPromotions::PromotionCode.create!(
               value: value,
               promotion: promotion,
               promotion_code_batch: promotion_code_batch
             )
-          end
+          rescue ActiveRecord::RecordInvalid
+            nil
+          end.compact
           created_codes += codes_for_current_batch.size
         end
       end


### PR DESCRIPTION
Backport Solidus PR 5383 with PR description:

When a new promotion with 2.5m new promo codes has created, it just generated about 250k promo codes and then stopped.

The PromotionBatch screen this error: Errored: #<ActiveRecord::RecordInvalid: Validation failed: Value has already been taken>

This PR rescues the exception raised by the Spree::PromotionCode creation and jumps to the next code to save, avoiding stopping the process completely. The PR also adds the ability to restart the PromotionCodeBatch from the latest PromotionCodes created.


Cf https://github.com/solidusio/solidus/pull/5383
