### PR TITLE
Add a PromotionHandler::Coupon

### DIFF
--- a/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
@@ -10,6 +10,10 @@ module SolidusFriendlyPromotions
       def available_calculators
         SolidusFriendlyPromotions.config.line_item_discount_calculators
       end
+
+      def level
+        :line_item
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
@@ -10,6 +10,10 @@ module SolidusFriendlyPromotions
       def available_calculators
         SolidusFriendlyPromotions.config.shipment_discount_calculators
       end
+
+      def level
+        :shipment
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
+++ b/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
@@ -29,7 +29,7 @@ module SolidusFriendlyPromotions
 
       def eligible_line_items(order)
         order.line_items.reject do |line_item|
-          SolidusFriendlyPromotions::PromotionEligibility.new(
+          SolidusFriendlyPromotions::PromotionsEligibility.new(
             promotable: line_item,
             possible_promotions: [calculable.promotion]
           ).call.empty?

--- a/app/models/solidus_friendly_promotions/eligibility_result.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_result.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusFriendlyPromotions
-  EligibilityResult = Struct.new(:item, :success, :code, :message, keyword_init: true)
+  EligibilityResult = Struct.new(:item, :rule, :success, :code, :message, keyword_init: true)
 end

--- a/app/models/solidus_friendly_promotions/eligibility_result.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_result.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  EligibilityResult = Struct.new(:item, :success, :code, :message, keyword_init: true)
+end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class EligibilityResults
+    attr_accessor :results_by_promotion
+    def initialize
+      @results_by_promotion = {}
+    end
+
+    def add(item:, rule:, success:, code:, message:)
+      results_by_promotion[rule.promotion] ||= {}
+      results_by_promotion[rule.promotion][rule] ||= []
+      results_by_promotion[rule.promotion][rule] << EligibilityResult.new(
+        item: item,
+        success: success,
+        code: code,
+        message: message
+      )
+    end
+
+    def for(promotion)
+      results_by_promotion[promotion]
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -21,5 +21,25 @@ module SolidusFriendlyPromotions
     def for(promotion)
       results_by_promotion[promotion]
     end
+
+    def success?(promotion)
+      results_for_promotion = self.for(promotion)
+      return true unless results_for_promotion
+      promotion.actions.any? do |action|
+        action.relevant_rules.all? do |rule|
+          results_for_promotion[rule].present? &&
+            results_for_promotion[rule].any?(&:success)
+        end
+      end
+    end
+
+    def errors_for(promotion)
+      results_for_promotion = self.for(promotion)
+      return [] unless results_for_promotion
+      results_for_promotion.map do |rule, results|
+        next if results.any?(&:success)
+        results.detect { |r| !r.success }&.message
+      end.compact
+    end
   end
 end

--- a/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
@@ -2,14 +2,12 @@
 
 module SolidusFriendlyPromotions
   class FriendlyPromotionDiscounter
-    attr_reader :order, :promotions, :eligibility_results
+    attr_reader :order, :promotions, :collect_eligibility_results
 
     def initialize(order, promotions, collect_eligibility_results: false)
       @order = order
       @promotions = promotions
-      if collect_eligibility_results
-        @eligibility_results = EligibilityResults.new
-      end
+      @collect_eligibility_results = collect_eligibility_results
     end
 
     def call
@@ -21,9 +19,10 @@ module SolidusFriendlyPromotions
         lane_promotions = PromotionsEligibility.new(
           promotable: order,
           possible_promotions: promotions.select { |promotion| promotion.lane == lane },
-          eligibility_results: eligibility_results
+          collect_eligibility_results: collect_eligibility_results
         ).call
-        item_discounter = ItemDiscounter.new(promotions: lane_promotions, eligibility_results: eligibility_results)
+
+        item_discounter = ItemDiscounter.new(promotions: lane_promotions, collect_eligibility_results: collect_eligibility_results)
         line_item_discounts = adjust_line_items(item_discounter)
         shipment_discounts = adjust_shipments(item_discounter)
         shipping_rate_discounts = adjust_shipping_rates(item_discounter)

--- a/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
@@ -15,7 +15,7 @@ module SolidusFriendlyPromotions
       order.reset_current_discounts
 
       SolidusFriendlyPromotions::Promotion.ordered_lanes.each do |lane, _index|
-        lane_promotions = PromotionEligibility.new(
+        lane_promotions = PromotionsEligibility.new(
           promotable: order,
           possible_promotions: promotions.select { |promotion| promotion.lane == lane }
         ).call

--- a/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
@@ -4,9 +4,9 @@ module SolidusFriendlyPromotions
   class FriendlyPromotionDiscounter
     attr_reader :order, :promotions, :eligibility_results
 
-    def initialize(order, collect_eligibility_results: false)
+    def initialize(order, promotions, collect_eligibility_results: false)
       @order = order
-      @promotions = PromotionLoader.new(order: order).call
+      @promotions = promotions
       if collect_eligibility_results
         @eligibility_results = EligibilityResults.new
       end

--- a/app/models/solidus_friendly_promotions/item_discounter.rb
+++ b/app/models/solidus_friendly_promotions/item_discounter.rb
@@ -2,18 +2,18 @@
 
 module SolidusFriendlyPromotions
   class ItemDiscounter
-    attr_reader :promotions, :eligibility_results
+    attr_reader :promotions, :collect_eligibility_results
 
-    def initialize(promotions:, eligibility_results: nil)
+    def initialize(promotions:, collect_eligibility_results: false)
       @promotions = promotions
-      @eligibility_results = eligibility_results
+      @collect_eligibility_results = collect_eligibility_results
     end
 
     def call(item)
       eligible_promotions = PromotionsEligibility.new(
         promotable: item,
         possible_promotions: promotions,
-        eligibility_results: eligibility_results
+        collect_eligibility_results: collect_eligibility_results
       ).call
 
       eligible_promotions.flat_map do |promotion|

--- a/app/models/solidus_friendly_promotions/item_discounter.rb
+++ b/app/models/solidus_friendly_promotions/item_discounter.rb
@@ -2,16 +2,18 @@
 
 module SolidusFriendlyPromotions
   class ItemDiscounter
-    attr_reader :promotions
+    attr_reader :promotions, :eligibility_results
 
-    def initialize(promotions:)
+    def initialize(promotions:, eligibility_results: nil)
       @promotions = promotions
+      @eligibility_results = eligibility_results
     end
 
     def call(item)
       eligible_promotions = PromotionsEligibility.new(
         promotable: item,
-        possible_promotions: promotions
+        possible_promotions: promotions,
+        eligibility_results: eligibility_results
       ).call
 
       eligible_promotions.flat_map do |promotion|

--- a/app/models/solidus_friendly_promotions/item_discounter.rb
+++ b/app/models/solidus_friendly_promotions/item_discounter.rb
@@ -9,7 +9,7 @@ module SolidusFriendlyPromotions
     end
 
     def call(item)
-      eligible_promotions = PromotionEligibility.new(
+      eligible_promotions = PromotionsEligibility.new(
         promotable: item,
         possible_promotions: promotions
       ).call

--- a/app/models/solidus_friendly_promotions/order_discounter.rb
+++ b/app/models/solidus_friendly_promotions/order_discounter.rb
@@ -2,12 +2,15 @@
 
 module SolidusFriendlyPromotions
   class OrderDiscounter
+    attr_reader :promotions
+
     def initialize(order)
       @order = order
+      @promotions = PromotionLoader.new(order: order).call
     end
 
     def call
-      discountable_order = FriendlyPromotionDiscounter.new(order).call
+      discountable_order = FriendlyPromotionDiscounter.new(order, promotions).call
 
       discountable_order.line_items.each do |line_item|
         update_adjustments(line_item, line_item.current_discounts)

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -122,6 +122,10 @@ module SolidusFriendlyPromotions
       rules.where(type: "SolidusFriendlyPromotions::Rules::Product").flat_map(&:products).uniq
     end
 
+    def eligibility_results
+      @eligibility_results ||= SolidusFriendlyPromotions::EligibilityResults.new(self)
+    end
+
     private
 
     def apply_automatically_disallowed_with_paths

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -58,6 +58,12 @@ module SolidusFriendlyPromotions
       raise NotImplementedError
     end
 
+    def relevant_rules
+      promotion.rules.select do |rule|
+        rule.level.in?([:order, level].uniq)
+      end
+    end
+
     def available_calculators
       raise NotImplementedError
     end

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -54,6 +54,10 @@ module SolidusFriendlyPromotions
       "solidus_friendly_promotions/admin/promotion_actions/actions/#{model_name.element}"
     end
 
+    def level
+      raise NotImplementedError
+    end
+
     def available_calculators
       raise NotImplementedError
     end

--- a/app/models/solidus_friendly_promotions/promotion_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotion_eligibility.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class PromotionEligibility
+    attr_reader :promotable, :promotion, :eligibility_results
+
+    def initialize(promotable:, promotion:, eligibility_results: nil)
+      @promotable = promotable
+      @promotion = promotion
+      @eligibility_results = eligibility_results
+    end
+
+    def call
+      applicable_rules = promotion.rules.select do |rule|
+        rule.applicable?(promotable)
+      end
+
+      applicable_rules.map do |applicable_rule|
+        eligible = applicable_rule.eligible?(promotable)
+
+        break [false] if !eligible && !eligibility_results
+
+        if eligibility_results
+          if applicable_rule.eligibility_errors.details[:base].first
+            code = applicable_rule.eligibility_errors.details[:base].first[:error_code]
+            message = applicable_rule.eligibility_errors.full_messages.first
+          end
+          eligibility_results.add(
+            item: promotable,
+            rule: applicable_rule,
+            success: eligible,
+            code: eligible ? nil : (code || :unknown_error),
+            message: eligible ? nil : (message || I18n.t(:unknown_error, scope: [:solidus_friendly_promotions, :eligibility_errors]))
+          )
+        end
+
+        eligible
+      end.all?
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/promotion_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotion_eligibility.rb
@@ -2,12 +2,12 @@
 
 module SolidusFriendlyPromotions
   class PromotionEligibility
-    attr_reader :promotable, :promotion, :eligibility_results
+    attr_reader :promotable, :promotion, :collect_eligibility_results
 
-    def initialize(promotable:, promotion:, eligibility_results: nil)
+    def initialize(promotable:, promotion:, collect_eligibility_results:)
       @promotable = promotable
       @promotion = promotion
-      @eligibility_results = eligibility_results
+      @collect_eligibility_results = collect_eligibility_results
     end
 
     def call
@@ -18,14 +18,14 @@ module SolidusFriendlyPromotions
       applicable_rules.map do |applicable_rule|
         eligible = applicable_rule.eligible?(promotable)
 
-        break [false] if !eligible && !eligibility_results
+        break [false] if !eligible && !collect_eligibility_results
 
-        if eligibility_results
+        if collect_eligibility_results
           if applicable_rule.eligibility_errors.details[:base].first
             code = applicable_rule.eligibility_errors.details[:base].first[:error_code]
             message = applicable_rule.eligibility_errors.full_messages.first
           end
-          eligibility_results.add(
+          promotion.eligibility_results.add(
             item: promotable,
             rule: applicable_rule,
             success: eligible,

--- a/app/models/solidus_friendly_promotions/promotion_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotion_eligibility.rb
@@ -29,8 +29,8 @@ module SolidusFriendlyPromotions
             item: promotable,
             rule: applicable_rule,
             success: eligible,
-            code: eligible ? nil : (code || :unknown_error),
-            message: eligible ? nil : (message || I18n.t(:unknown_error, scope: [:solidus_friendly_promotions, :eligibility_errors]))
+            code: eligible ? nil : (code || :coupon_code_unknown_error),
+            message: eligible ? nil : (message || I18n.t(:coupon_code_unknown_error, scope: [:solidus_friendly_promotions, :eligibility_errors]))
           )
         end
 

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module PromotionHandler
+    class Coupon
+      attr_reader :order, :coupon_code
+      attr_accessor :error, :success, :status_code
+
+      def initialize(order)
+        @order = order
+        @coupon_code = order&.coupon_code&.downcase
+      end
+
+      def apply
+        if coupon_code.present?
+          if promotion.present? && promotion.active? && promotion.actions.exists?
+            handle_present_promotion
+          elsif promotion_code&.promotion&.expired?
+            set_error_code :coupon_code_expired
+          else
+            set_error_code :coupon_code_not_found
+          end
+        end
+
+        self
+      end
+
+      def remove
+        if promotion.blank?
+          set_error_code :coupon_code_not_found
+        elsif !promotion_exists_on_order?(order, promotion)
+          set_error_code :coupon_code_not_present
+        else
+          order.friendly_order_promotions.destroy_by(
+            promotion: promotion
+          )
+          order.recalculate
+          set_success_code :coupon_code_removed
+        end
+
+        self
+      end
+
+      def set_success_code(status_code)
+        @status_code = status_code
+        @success = I18n.t(status_code, scope: "solidus_friendly_promotions.eligibility_results")
+      end
+
+      def set_error_code(status_code, options = {})
+        @status_code = status_code
+        @error = options[:error] || I18n.t(status_code, scope: "solidus_friendly_promotions.eligibility_errors")
+      end
+
+      def promotion
+        @promotion ||= if promotion_code&.promotion&.active?
+          promotion_code.promotion
+        end
+      end
+
+      def successful?
+        success.present? && error.blank?
+      end
+
+      private
+
+      def promotion_code
+        @promotion_code ||= SolidusFriendlyPromotions::PromotionCode.where(value: coupon_code).first
+      end
+
+      def handle_present_promotion
+        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded? || promotion_code.usage_limit_exceeded?
+        return promotion_applied if promotion_exists_on_order?(order, promotion)
+
+        # Try applying this promotion, with no effects
+        active_promotions = SolidusFriendlyPromotions::PromotionLoader.new(order: order).call
+        discounter = SolidusFriendlyPromotions::FriendlyPromotionDiscounter.new(order, active_promotions + [promotion], collect_eligibility_results: true)
+        discounter.call
+        if discounter.eligibility_results.success?(promotion)
+          order.friendly_order_promotions.create!(
+            promotion: promotion,
+            promotion_code: promotion_code
+          )
+          order.recalculate
+          set_success_code :coupon_code_applied
+        else
+          set_promotion_eligibility_error(promotion, discounter.eligibility_results)
+        end
+      end
+
+      def set_promotion_eligibility_error(promotion, results)
+        eligibility_error = results.for(promotion).values.flatten.detect { |result| !result.success }
+
+        @status_code = eligibility_error.code
+        @error = eligibility_error.message
+      end
+
+      def promotion_usage_limit_exceeded
+        set_error_code :coupon_code_max_usage
+      end
+
+      def ineligible_for_this_order
+        set_error_code :coupon_code_not_eligible
+      end
+
+      def promotion_applied
+        set_error_code :coupon_code_already_applied
+      end
+
+      def promotion_exists_on_order?(order, promotion)
+        order.friendly_promotions.include? promotion
+      end
+    end
+  end
+end

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -90,7 +90,7 @@ module SolidusFriendlyPromotions
       end
 
       def set_promotion_eligibility_error(promotion, results)
-        eligibility_error = results.for(promotion).values.flatten.detect { |result| !result.success }
+        eligibility_error = results.for(promotion).detect { |result| !result.success }
         set_error_code(eligibility_error.code, error: eligibility_error.message, errors: results.errors_for(promotion))
       end
 

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -77,7 +77,7 @@ module SolidusFriendlyPromotions
         active_promotions = SolidusFriendlyPromotions::PromotionLoader.new(order: order).call
         discounter = SolidusFriendlyPromotions::FriendlyPromotionDiscounter.new(order, active_promotions + [promotion], collect_eligibility_results: true)
         discounter.call
-        if discounter.eligibility_results.success?(promotion)
+        if promotion.eligibility_results.success?
           order.friendly_order_promotions.create!(
             promotion: promotion,
             promotion_code: promotion_code
@@ -85,13 +85,13 @@ module SolidusFriendlyPromotions
           order.recalculate
           set_success_code :coupon_code_applied
         else
-          set_promotion_eligibility_error(promotion, discounter.eligibility_results)
+          set_promotion_eligibility_error(promotion)
         end
       end
 
-      def set_promotion_eligibility_error(promotion, results)
-        eligibility_error = results.for(promotion).detect { |result| !result.success }
-        set_error_code(eligibility_error.code, error: eligibility_error.message, errors: results.errors_for(promotion))
+      def set_promotion_eligibility_error(promotion)
+        eligibility_error = promotion.eligibility_results.detect { |result| !result.success }
+        set_error_code(eligibility_error.code, error: eligibility_error.message, errors: promotion.eligibility_results.error_messages)
       end
 
       def promotion_usage_limit_exceeded

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -41,6 +41,18 @@ module SolidusFriendlyPromotions
         self
       end
 
+      def successful?
+        success.present? && error.blank?
+      end
+
+      def promotion
+        @promotion ||= if promotion_code&.promotion&.active?
+          promotion_code.promotion
+        end
+      end
+
+      private
+
       def set_success_code(status_code)
         @status_code = status_code
         @success = I18n.t(status_code, scope: "solidus_friendly_promotions.eligibility_results")
@@ -50,18 +62,6 @@ module SolidusFriendlyPromotions
         @status_code = status_code
         @error = options[:error] || I18n.t(status_code, scope: "solidus_friendly_promotions.eligibility_errors")
       end
-
-      def promotion
-        @promotion ||= if promotion_code&.promotion&.active?
-          promotion_code.promotion
-        end
-      end
-
-      def successful?
-        success.present? && error.blank?
-      end
-
-      private
 
       def promotion_code
         @promotion_code ||= SolidusFriendlyPromotions::PromotionCode.where(value: coupon_code).first

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -3,11 +3,12 @@
 module SolidusFriendlyPromotions
   module PromotionHandler
     class Coupon
-      attr_reader :order, :coupon_code
+      attr_reader :order, :coupon_code, :errors
       attr_accessor :error, :success, :status_code
 
       def initialize(order)
         @order = order
+        @errors = []
         @coupon_code = order&.coupon_code&.downcase
       end
 
@@ -61,6 +62,7 @@ module SolidusFriendlyPromotions
       def set_error_code(status_code, options = {})
         @status_code = status_code
         @error = options[:error] || I18n.t(status_code, scope: "solidus_friendly_promotions.eligibility_errors")
+        @errors = options[:errors] || [@error]
       end
 
       def promotion_code
@@ -89,9 +91,7 @@ module SolidusFriendlyPromotions
 
       def set_promotion_eligibility_error(promotion, results)
         eligibility_error = results.for(promotion).values.flatten.detect { |result| !result.success }
-
-        @status_code = eligibility_error.code
-        @error = eligibility_error.message
+        set_error_code(eligibility_error.code, error: eligibility_error.message, errors: results.errors_for(promotion))
       end
 
       def promotion_usage_limit_exceeded

--- a/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/coupon.rb
@@ -13,7 +13,7 @@ module SolidusFriendlyPromotions
 
       def apply
         if coupon_code.present?
-          if promotion.present? && promotion.active? && promotion.actions.exists?
+          if promotion.present? && promotion.active?
             handle_present_promotion
           elsif promotion_code&.promotion&.expired?
             set_error_code :coupon_code_expired

--- a/app/models/solidus_friendly_promotions/promotions_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotions_eligibility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusFriendlyPromotions
-  class PromotionEligibility
+  class PromotionsEligibility
     attr_reader :promotable, :possible_promotions
 
     def initialize(promotable:, possible_promotions:)

--- a/app/models/solidus_friendly_promotions/promotions_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotions_eligibility.rb
@@ -2,22 +2,17 @@
 
 module SolidusFriendlyPromotions
   class PromotionsEligibility
-    attr_reader :promotable, :possible_promotions
+    attr_reader :promotable, :possible_promotions, :eligibility_results
 
-    def initialize(promotable:, possible_promotions:)
+    def initialize(promotable:, possible_promotions:, eligibility_results: nil)
       @promotable = promotable
       @possible_promotions = possible_promotions
+      @eligibility_results = eligibility_results
     end
 
     def call
       possible_promotions.select do |candidate|
-        applicable_rules = candidate.rules.select do |rule|
-          rule.applicable?(promotable)
-        end
-
-        applicable_rules.all? do |applicable_rule|
-          applicable_rule.eligible?(promotable)
-        end
+        PromotionEligibility.new(promotable: promotable, promotion: candidate, eligibility_results: eligibility_results).call
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/promotions_eligibility.rb
+++ b/app/models/solidus_friendly_promotions/promotions_eligibility.rb
@@ -2,17 +2,17 @@
 
 module SolidusFriendlyPromotions
   class PromotionsEligibility
-    attr_reader :promotable, :possible_promotions, :eligibility_results
+    attr_reader :promotable, :possible_promotions, :collect_eligibility_results
 
-    def initialize(promotable:, possible_promotions:, eligibility_results: nil)
+    def initialize(promotable:, possible_promotions:, collect_eligibility_results: false)
       @promotable = promotable
       @possible_promotions = possible_promotions
-      @eligibility_results = eligibility_results
+      @collect_eligibility_results = collect_eligibility_results
     end
 
     def call
       possible_promotions.select do |candidate|
-        PromotionEligibility.new(promotable: promotable, promotion: candidate, eligibility_results: eligibility_results).call
+        PromotionEligibility.new(promotable: promotable, promotion: candidate, collect_eligibility_results: collect_eligibility_results).call
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,16 +52,17 @@ en:
       solidus_friendly_promotions/calculator:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
     coupon_code: Coupon code
+    eligibility_results:
+      coupon_code_applied: The coupon code was successfully applied to your order.
+      coupon_code_removed: The coupon code was successfully removed from this order.
     eligibility_errors:
-      already_applied: The coupon code has already been applied to this order
-      applied: The coupon code was successfully applied to your order.
-      expired: The coupon code is expired
-      max_usage: Coupon code usage limit exceeded
-      not_eligible: This coupon code is not eligible for this order
-      not_found: The coupon code you entered doesn't exist. Please try again.
-      not_present: The coupon code you are trying to remove is not present on this order.
-      removed: The coupon code was successfully removed from this order.
-      unknown_error: This coupon code could not be applied to the cart at this time.
+      coupon_code_already_applied: The coupon code has already been applied to this order
+      coupon_code_expired: The coupon code is expired
+      coupon_code_max_usage: Coupon code usage limit exceeded
+      coupon_code_not_eligible: This coupon code is not eligible for this order
+      coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
+      coupon_code_not_present: The coupon code you are trying to remove is not present on this order.
+      coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
       solidus_friendly_promotions/rules/first_order:
         not_first_order: This coupon code can only be applied to your first order.
       solidus_friendly_promotions/rules/first_repeat_purchase_since:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,17 @@ en:
     hints:
       solidus_friendly_promotions/calculator:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
+    coupon_code: Coupon code
     eligibility_errors:
+      already_applied: The coupon code has already been applied to this order
+      applied: The coupon code was successfully applied to your order.
+      expired: The coupon code is expired
+      max_usage: Coupon code usage limit exceeded
+      not_eligible: This coupon code is not eligible for this order
+      not_found: The coupon code you entered doesn't exist. Please try again.
+      not_present: The coupon code you are trying to remove is not present on this order.
+      removed: The coupon code was successfully removed from this order.
+      unknown_error: This coupon code could not be applied to the cart at this time.
       solidus_friendly_promotions/rules/first_order:
         not_first_order: This coupon code can only be applied to your first order.
       solidus_friendly_promotions/rules/first_repeat_purchase_since:

--- a/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
@@ -22,4 +22,20 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustLineItem do
 
     it { is_expected.to eq(:line_item) }
   end
+
+  describe "#relevant_rules" do
+    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
+    let(:action) { described_class.new(calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
+    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
+    let(:product) { create(:product) }
+    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
+    let(:ups) { create(:shipping_method) }
+    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
+
+    subject { action.relevant_rules }
+
+    it { is_expected.to contain_exactly(order_rule, line_item_rule) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustLineItem do
 
     it { is_expected.to eq("solidus_friendly_promotions/admin/promotion_actions/actions/adjust_line_item") }
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it { is_expected.to eq(:line_item) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
@@ -38,4 +38,20 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustShipment do
 
     it { is_expected.to eq(:shipment) }
   end
+
+  describe "#relevant_rules" do
+    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
+    let(:action) { described_class.new(calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
+    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
+    let(:product) { create(:product) }
+    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
+    let(:ups) { create(:shipping_method) }
+    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
+
+    subject { action.relevant_rules }
+
+    it { is_expected.to contain_exactly(order_rule, shipment_rule) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustShipment do
       it { is_expected.to be true }
     end
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it { is_expected.to eq(:shipment) }
+  end
 end

--- a/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::EligibilityResult do
+  it { is_expected.to respond_to(:item) }
+  it { is_expected.to respond_to(:success) }
+  it { is_expected.to respond_to(:code) }
+  it { is_expected.to respond_to(:message) }
+end

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
+  subject(:eligibility_results) { described_class.new }
+
+  describe "#add" do
+    let(:promotion) { create(:friendly_promotion) }
+    let(:order) { create(:order, item_total: 100) }
+    let(:rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(promotion: promotion, preferred_amount: 101) }
+
+    it "can add an error result" do
+      result = rule.eligible?(order)
+
+      eligibility_results.add(
+        item: order,
+        rule: rule,
+        success: result,
+        code: rule.eligibility_errors.details[:base].first[:error_code],
+        message: rule.eligibility_errors.full_messages.first
+      )
+
+      expect(eligibility_results.for(promotion)).to eq({
+        rule => [
+          SolidusFriendlyPromotions::EligibilityResult.new(
+            item: order,
+            success: result,
+            code: rule.eligibility_errors.details[:base].first[:error_code],
+            message: rule.eligibility_errors.full_messages.first
+          )
+        ]
+      })
+    end
+  end
+end

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
-  subject(:eligibility_results) { described_class.new }
+  subject(:eligibility_results) { described_class.new(promotion) }
 
   describe "#add" do
     let(:promotion) { create(:friendly_promotion) }
@@ -21,7 +21,7 @@ RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
         message: rule.eligibility_errors.full_messages.first
       )
 
-      expect(eligibility_results.for(promotion)).to eq([
+      expect(eligibility_results.to_a).to eq([
         SolidusFriendlyPromotions::EligibilityResult.new(
           item: order,
           rule: rule,

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -21,16 +21,15 @@ RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
         message: rule.eligibility_errors.full_messages.first
       )
 
-      expect(eligibility_results.for(promotion)).to eq({
-        rule => [
-          SolidusFriendlyPromotions::EligibilityResult.new(
-            item: order,
-            success: result,
-            code: rule.eligibility_errors.details[:base].first[:error_code],
-            message: rule.eligibility_errors.full_messages.first
-          )
-        ]
-      })
+      expect(eligibility_results.for(promotion)).to eq([
+        SolidusFriendlyPromotions::EligibilityResult.new(
+          item: order,
+          rule: rule,
+          success: result,
+          code: rule.eligibility_errors.details[:base].first[:error_code],
+          message: rule.eligibility_errors.full_messages.first
+        )
+      ])
     end
   end
 end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -13,4 +13,146 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
       expect(subject).to eq(order)
     end
   end
+
+  describe "collecting eligibility results" do
+    let(:shirt) { create(:product, name: "Shirt") }
+    let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}]) }
+    let(:rules) { [product_rule] }
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, rules: rules, name: "20% off Shirts", apply_automatically: true) }
+    let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+    let(:discounter) { described_class.new(order, collect_eligibility_results: true) }
+
+    subject { discounter.call }
+
+    it "will collect eligibility results" do
+      subject
+
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
+      expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
+    end
+
+    it "can tell us about success" do
+      subject
+      expect(discounter.eligibility_results.success?(promotion)).to be true
+    end
+
+    context "with two rules" do
+      let(:rules) { [product_rule, item_total_rule] }
+      let(:item_total_rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(preferred_amount: 2000) }
+
+      it "will collect eligibility results" do
+        subject
+
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
+        expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.success).to be false
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.code).to eq :item_total_less_than_or_equal
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.message).to eq "This coupon code can't be applied to orders less than or equal to $2,000.00."
+        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.item).to eq(order)
+      end
+
+      it "can tell us about success" do
+        subject
+        expect(discounter.eligibility_results.success?(promotion)).to be false
+      end
+
+      it "has errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to eq([
+          "This coupon code can't be applied to orders less than or equal to $2,000.00."
+        ])
+      end
+    end
+
+    context "with an order with multiple line items and an item-level rule" do
+      let(:pants) { create(:product, name: "Pants") }
+      let(:order) do
+        create(
+          :order_with_line_items,
+          line_items_attributes: [{variant: shirt.master, quantity: 1}, {variant: pants.master, quantity: 1}]
+        )
+      end
+
+      let(:shirt_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [shirt]) }
+      let(:rules) { [shirt_product_rule] }
+
+      it "can tell us about success" do
+        subject
+        # This is successful, because one of the line item rules matches
+        expect(discounter.eligibility_results.success?(promotion)).to be true
+      end
+
+      it "has no errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to be_empty
+      end
+
+      context "with a second line item level rule" do
+        let(:hat) { create(:product) }
+        let(:hat_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [hat]) }
+        let(:rules) { [shirt_product_rule, hat_product_rule] }
+
+        it "can tell us about success" do
+          subject
+          expect(discounter.eligibility_results.success?(promotion)).to be false
+        end
+
+        it "has errors for this promo" do
+          subject
+          expect(discounter.eligibility_results.errors_for(promotion)).to eq([
+            "You need to add an applicable product before applying this coupon code."
+          ])
+        end
+      end
+    end
+
+    context "when the order must not contain a shirt" do
+      let(:no_shirt_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_match_policy: "none", preferred_line_item_applicable: false) }
+      let(:rules) { [no_shirt_rule] }
+
+      it "can tell us about success" do
+        subject
+        # This is successful, because the order has a shirt
+        expect(discounter.eligibility_results.success?(promotion)).to be false
+      end
+    end
+
+    context "with a promotion with a line-item level action and a shipment-level action where only one action succeeds" do
+      let(:usps) { create(:shipping_method) }
+      let(:ups_ground) { create(:shipping_method) }
+      let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}], shipping_method: ups_ground) }
+      let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+      let(:shipping_method_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [usps.id]) }
+      let(:ten_off_items) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
+      let(:ten_off_shipping) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
+      let(:shipping_action) { SolidusFriendlyPromotions::Actions::AdjustShipment.new(calculator: ten_off_shipping) }
+      let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items) }
+      let(:actions) { [shipping_action, line_item_action] }
+      let(:rules) { [product_rule, shipping_method_rule] }
+      let!(:promotion) { create(:friendly_promotion, actions: actions, rules: rules, name: "10% off Shirts and USPS Shipping", apply_automatically: true) }
+
+      it "can tell us about success" do
+        subject
+        expect(discounter.eligibility_results.success?(promotion)).to be true
+      end
+
+      it "can tell us about errors" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to eq(["This coupon code could not be applied to the cart at this time."])
+      end
+    end
+
+    context "with no rules" do
+      let(:rules) { [] }
+
+      it "has no errors for this promo" do
+        subject
+        expect(discounter.eligibility_results.errors_for(promotion)).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
   context "shipped orders" do
+    let(:promotions) { [] }
     let(:order) { create(:order, shipment_state: "shipped") }
 
-    subject { described_class.new(order).call }
+    subject { described_class.new(order, promotions).call }
 
     it "returns the order unmodified" do
       expect(order).not_to receive(:reset_current_discounts)
@@ -20,7 +21,8 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
     let(:rules) { [product_rule] }
     let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, rules: rules, name: "20% off Shirts", apply_automatically: true) }
     let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
-    let(:discounter) { described_class.new(order, collect_eligibility_results: true) }
+    let(:promotions) { SolidusFriendlyPromotions::PromotionLoader.new(order: order).call }
+    let(:discounter) { described_class.new(order, promotions, collect_eligibility_results: true) }
 
     subject { discounter.call }
 

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -29,10 +29,11 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
     it "will collect eligibility results" do
       subject
 
-      expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
-      expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
-      expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
-      expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
+      expect(discounter.eligibility_results.for(promotion).first.success).to be true
+      expect(discounter.eligibility_results.for(promotion).first.code).to be nil
+      expect(discounter.eligibility_results.for(promotion).first.rule).to eq(product_rule)
+      expect(discounter.eligibility_results.for(promotion).first.message).to be nil
+      expect(discounter.eligibility_results.for(promotion).first.item).to eq(order)
     end
 
     it "can tell us about success" do
@@ -47,14 +48,16 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
       it "will collect eligibility results" do
         subject
 
-        expect(discounter.eligibility_results.for(promotion)[product_rule].first.success).to be true
-        expect(discounter.eligibility_results.for(promotion)[product_rule].first.code).to be nil
-        expect(discounter.eligibility_results.for(promotion)[product_rule].first.message).to be nil
-        expect(discounter.eligibility_results.for(promotion)[product_rule].first.item).to eq(order)
-        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.success).to be false
-        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.code).to eq :item_total_less_than_or_equal
-        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.message).to eq "This coupon code can't be applied to orders less than or equal to $2,000.00."
-        expect(discounter.eligibility_results.for(promotion)[item_total_rule].first.item).to eq(order)
+        expect(discounter.eligibility_results.for(promotion).first.success).to be true
+        expect(discounter.eligibility_results.for(promotion).first.code).to be nil
+        expect(discounter.eligibility_results.for(promotion).first.rule).to eq(product_rule)
+        expect(discounter.eligibility_results.for(promotion).first.message).to be nil
+        expect(discounter.eligibility_results.for(promotion).first.item).to eq(order)
+        expect(discounter.eligibility_results.for(promotion).last.success).to be false
+        expect(discounter.eligibility_results.for(promotion).last.rule).to eq(item_total_rule)
+        expect(discounter.eligibility_results.for(promotion).last.code).to eq :item_total_less_than_or_equal
+        expect(discounter.eligibility_results.for(promotion).last.message).to eq "This coupon code can't be applied to orders less than or equal to $2,000.00."
+        expect(discounter.eligibility_results.for(promotion).last.item).to eq(order)
       end
 
       it "can tell us about success" do

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe SolidusFriendlyPromotions::PromotionAction do
       expect(subject).to be_nil
     end
   end
+
+  describe "#level" do
+    subject { described_class.new.level }
+
+    it "raises an error" do
+      expect { subject }.to raise_exception(NotImplementedError)
+    end
+  end
 end

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
     describe "#set_success_code" do
       let(:status) { :coupon_code_applied }
-      subject { coupon.set_success_code status }
+      subject { coupon.send(:set_success_code, status) }
 
       it "should have status_code" do
         subject
@@ -39,7 +39,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
     end
 
     describe "#set_error_code" do
-      subject { coupon.set_error_code status }
+      subject { coupon.send(:set_error_code, status) }
 
       context "not found" do
         let(:status) { :coupon_code_not_found }

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
       it "should have success message" do
         subject
-        expect(coupon.success).to eq(I18n.t(status, scope: "spree"))
+        expect(coupon.success).to eq "The coupon code was successfully applied to your order."
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
         it "has error message" do
           subject
-          expect(coupon.error).to eq(I18n.t(status, scope: "spree"))
+          expect(coupon.error).to eq "The coupon code you entered doesn't exist. Please try again."
         end
       end
 
@@ -66,7 +66,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
         it "has error message" do
           subject
-          expect(coupon.error).to eq(I18n.t(status, scope: "spree"))
+          expect(coupon.error).to eq "The coupon code you are trying to remove is not present on this order."
         end
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
       it "populates error message" do
         subject.apply
-        expect(subject.error).to eq I18n.t("spree.coupon_code_not_found")
+        expect(subject.error).to eq "The coupon code you entered doesn't exist. Please try again."
       end
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
             subject.apply
             expect(subject.success).to be_present
             subject.apply
-            expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+            expect(subject.error).to eq "The coupon code has already been applied to this order"
           end
         end
 
@@ -218,7 +218,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
           subject.apply
           expect(subject.success).to be_present
           subject.apply
-          expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+          expect(subject.error).to eq "The coupon code has already been applied to this order"
         end
       end
     end
@@ -258,7 +258,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
           it "returns a coupon has already been applied error" do
             subject.apply
-            expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+            expect(subject.error).to eq "The coupon code has already been applied to this order"
           end
         end
 
@@ -276,7 +276,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
           it "returns a coupon failed to activate error" do
             subject.apply
-            expect(subject.error).to eq I18n.t("spree.coupon_code_unknown_error")
+            expect(subject.error).to eq "This coupon code could not be applied to the cart at this time."
           end
         end
 
@@ -295,7 +295,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
           it "returns a coupon is at max usage error" do
             subject.apply
-            expect(subject.error).to eq I18n.t("spree.coupon_code_max_usage")
+            expect(subject.error).to eq "Coupon code usage limit exceeded"
           end
         end
       end
@@ -403,7 +403,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
       it "successfully removes the coupon code from the order" do
         subject.remove
         expect(subject.error).to eq nil
-        expect(subject.success).to eq I18n.t("spree.coupon_code_removed")
+        expect(subject.success).to eq "The coupon code was successfully removed from this order."
         expect(order.reload.total).to eq(130)
       end
     end
@@ -417,7 +417,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
       it "returns an error" do
         subject.remove
         expect(subject.success).to eq nil
-        expect(subject.error).to eq I18n.t("spree.coupon_code_not_present")
+        expect(subject.error).to eq "The coupon code you are trying to remove is not present on this order."
         expect(order.reload.total).to eq(130)
       end
     end

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
 
   def expect_adjustment_creation(adjustable:, promotion:, promotion_code: nil)
     expect(adjustable.adjustments.map(&:source).map(&:promotion)).to include(promotion)
-    # expect(adjustable.adjustments.map(&:promotion_code)).to include(promotion_code)
   end
 
   it "returns self in apply" do

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -1,0 +1,425 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model do
+  let(:order) { double("Order", coupon_code: "10off").as_null_object }
+
+  subject { described_class.new(order) }
+
+  def expect_order_connection(order:, promotion:, promotion_code: nil)
+    expect(order.friendly_promotions.to_a).to include(promotion)
+    expect(order.friendly_order_promotions.flat_map(&:promotion_code)).to include(promotion_code)
+  end
+
+  def expect_adjustment_creation(adjustable:, promotion:, promotion_code: nil)
+    expect(adjustable.adjustments.map(&:source).map(&:promotion)).to include(promotion)
+    # expect(adjustable.adjustments.map(&:promotion_code)).to include(promotion_code)
+  end
+
+  it "returns self in apply" do
+    expect(subject.apply).to be_a described_class
+  end
+
+  context "status messages" do
+    let(:coupon) { described_class.new(order) }
+
+    describe "#set_success_code" do
+      let(:status) { :coupon_code_applied }
+      subject { coupon.set_success_code status }
+
+      it "should have status_code" do
+        subject
+        expect(coupon.status_code).to eq(status)
+      end
+
+      it "should have success message" do
+        subject
+        expect(coupon.success).to eq(I18n.t(status, scope: "spree"))
+      end
+    end
+
+    describe "#set_error_code" do
+      subject { coupon.set_error_code status }
+
+      context "not found" do
+        let(:status) { :coupon_code_not_found }
+
+        it "has status_code" do
+          subject
+          expect(coupon.status_code).to eq(status)
+        end
+
+        it "has error message" do
+          subject
+          expect(coupon.error).to eq(I18n.t(status, scope: "spree"))
+        end
+      end
+
+      context "not present" do
+        let(:status) { :coupon_code_not_present }
+
+        it "has status_code" do
+          subject
+          expect(coupon.status_code).to eq(status)
+        end
+
+        it "has error message" do
+          subject
+          expect(coupon.error).to eq(I18n.t(status, scope: "spree"))
+        end
+      end
+    end
+  end
+
+  context "coupon code promotion doesnt exist" do
+    before { create(:promotion) }
+
+    it "doesnt fetch any promotion" do
+      expect(subject.promotion).to be_blank
+    end
+
+    context "with no actions defined" do
+      before { create(:promotion, code: "10off") }
+
+      it "populates error message" do
+        subject.apply
+        expect(subject.error).to eq I18n.t("spree.coupon_code_not_found")
+      end
+    end
+  end
+
+  context "existing coupon code promotion" do
+    let!(:promotion) { promotion_code.promotion }
+    let(:promotion_code) { create(:friendly_promotion_code, value: "10off") }
+    let!(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.create(promotion: promotion, calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+
+    it "fetches with given code" do
+      expect(subject.promotion).to eq promotion
+    end
+
+    context "with a per-item adjustment action" do
+      let(:order) { create(:order_with_line_items, line_items_count: 3) }
+
+      context "right coupon given" do
+        context "with correct coupon code casing" do
+          before { order.coupon_code = "10off" }
+
+          it "successfully activates promo" do
+            expect(order.total).to eq(130)
+            subject.apply
+            expect(subject.success).to be_present
+            expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
+            order.line_items.each do |line_item|
+              expect_adjustment_creation(adjustable: line_item, promotion: promotion, promotion_code: promotion_code)
+            end
+            # Ensure that applying the adjustment actually affects the order's total!
+            expect(order.reload.total).to eq(100)
+          end
+
+          it "coupon already applied to the order" do
+            subject.apply
+            expect(subject.success).to be_present
+            subject.apply
+            expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+          end
+        end
+
+        # Regression test for https://github.com/spree/spree/issues/4211
+        context "with incorrect coupon code casing" do
+          before { order.coupon_code = "10OFF" }
+          it "successfully activates promo" do
+            expect(order.total).to eq(130)
+            subject.apply
+            expect(subject.success).to be_present
+            expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
+            order.line_items.each do |line_item|
+              expect_adjustment_creation(adjustable: line_item, promotion: promotion, promotion_code: promotion_code)
+            end
+            # Ensure that applying the adjustment actually affects the order's total!
+            expect(order.reload.total).to eq(100)
+          end
+        end
+      end
+
+      context "coexists with a non coupon code promo" do
+        let!(:order) { create(:order) }
+
+        before do
+          order.coupon_code = "10off"
+          calculator = SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10)
+          general_promo = create(:friendly_promotion, lane: :post, apply_automatically: true, name: "General Promo")
+          SolidusFriendlyPromotions::Actions::AdjustLineItem.create(promotion: general_promo, calculator: calculator)
+
+          order.contents.add create(:variant)
+        end
+
+        # regression spec for https://github.com/spree/spree/issues/4515
+        it "successfully activates promo" do
+          subject.apply
+          expect(subject).to be_successful
+          expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
+          order.line_items.each do |line_item|
+            expect_adjustment_creation(adjustable: line_item, promotion: promotion, promotion_code: promotion_code)
+          end
+        end
+      end
+
+      context "applied alongside another valid promotion " do
+        let!(:order) { create(:order) }
+
+        before do
+          order.coupon_code = "10off"
+          calculator = SolidusFriendlyPromotions::Calculators::Percent.new(preferred_percent: 10)
+          general_promo = create(:friendly_promotion, lane: :pre, apply_automatically: true, name: "General Promo")
+          SolidusFriendlyPromotions::Actions::AdjustLineItem.create!(promotion: general_promo, calculator: calculator)
+
+          order.contents.add create(:variant, price: 500)
+          order.contents.add create(:variant, price: 10)
+        end
+
+        it "successfully activates both promotions and returns success" do
+          subject.apply
+          expect(subject).to be_successful
+          order.line_items.each do |line_item|
+            expect(line_item.adjustments.count).to eq 2
+            expect_adjustment_creation(adjustable: line_item, promotion: promotion, promotion_code: promotion_code)
+          end
+        end
+      end
+    end
+
+    context "with a free-shipping adjustment action" do
+      let!(:action) do
+        SolidusFriendlyPromotions::Actions::AdjustShipment.create!(
+          promotion: promotion,
+          calculator: calculator
+        )
+      end
+      let(:calculator) { SolidusFriendlyPromotions::Calculators::Percent.new(preferred_percent: 100) }
+      context "right coupon code given" do
+        let(:order) { create(:order_with_line_items, line_items_count: 3) }
+
+        before { order.coupon_code = "10off" }
+
+        it "successfully activates promo" do
+          expect(order.total).to eq(130)
+          subject.apply
+          expect(subject.success).to be_present
+
+          expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
+          order.shipments.each do |shipment|
+            expect_adjustment_creation(adjustable: shipment, promotion: promotion, promotion_code: promotion_code)
+          end
+        end
+
+        it "coupon already applied to the order" do
+          subject.apply
+          expect(subject.success).to be_present
+          subject.apply
+          expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+        end
+      end
+    end
+
+    context "with a whole-order adjustment action" do
+      let!(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.create(promotion: promotion, calculator: calculator) }
+      context "right coupon given" do
+        let(:order) { create(:order) }
+        let(:calculator) { SolidusFriendlyPromotions::Calculators::DistributedAmount.new(preferred_amount: 10) }
+
+        before do
+          allow(order).to receive_messages({
+            coupon_code: "10off",
+            # These need to be here so that promotion adjustment "wins"
+            item_total: 50,
+            ship_total: 10
+          })
+        end
+
+        it "successfully activates promo" do
+          subject.apply
+          expect(subject.success).to be_present
+          expect(order.all_adjustments.count).to eq(order.line_items.count)
+          expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
+          order.line_items.each do |line_item|
+            expect_adjustment_creation(adjustable: line_item, promotion: promotion, promotion_code: promotion_code)
+          end
+        end
+
+        context "when the coupon is already applied to the order" do
+          before { subject.apply }
+
+          it "is not successful" do
+            subject.apply
+            expect(subject.successful?).to be false
+          end
+
+          it "returns a coupon has already been applied error" do
+            subject.apply
+            expect(subject.error).to eq I18n.t("spree.coupon_code_already_applied")
+          end
+        end
+
+        context "when the coupon fails to activate" do
+          let(:impossible_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+
+          before do
+            promotion.rules << impossible_rule
+          end
+
+          it "is not successful" do
+            subject.apply
+            expect(subject.successful?).to be false
+          end
+
+          it "returns a coupon failed to activate error" do
+            subject.apply
+            expect(subject.error).to eq I18n.t("spree.coupon_code_unknown_error")
+          end
+        end
+
+        context "when the promotion exceeds its usage limit" do
+          let!(:second_order) { FactoryBot.create(:completed_order_with_friendly_promotion, promotion: promotion) }
+
+          before do
+            promotion.update!(usage_limit: 1)
+            described_class.new(second_order).apply
+          end
+
+          it "is not successful" do
+            subject.apply
+            expect(subject.successful?).to be false
+          end
+
+          it "returns a coupon is at max usage error" do
+            subject.apply
+            expect(subject.error).to eq I18n.t("spree.coupon_code_max_usage")
+          end
+        end
+      end
+    end
+
+    context "for an order with taxable line items" do
+      let(:store) { create(:store) }
+      let(:order) { create(:order, store: store) }
+      let(:tax_category) { create(:tax_category, name: "Taxable Foo") }
+      let(:zone) { create(:zone, :with_country) }
+      let!(:tax_rate) { create(:tax_rate, amount: 0.1, tax_categories: [tax_category], zone: zone) }
+
+      before(:each) do
+        expect(order).to receive(:tax_address).at_least(:once).and_return(Spree::Tax::TaxLocation.new(country: zone.countries.first))
+      end
+
+      context "and the product price is less than promo discount" do
+        before(:each) do
+          order.coupon_code = "10off"
+
+          3.times do |_i|
+            taxable = create(:product, tax_category: tax_category, price: 9.0)
+            order.contents.add(taxable.master, 1)
+          end
+        end
+
+        it "successfully applies the promo" do
+          # 3 * (9 + 0.9)
+          expect(order.total).to eq(29.7)
+          coupon = described_class.new(order)
+          coupon.apply
+          expect(coupon.success).to be_present
+          # 3 * ((9 - [9,10].min) + 0)
+          expect(order.reload.total).to eq(0)
+          expect(order.additional_tax_total).to eq(0)
+        end
+      end
+
+      context "and the product price is greater than promo discount" do
+        before(:each) do
+          order.coupon_code = "10off"
+
+          3.times do |_i|
+            taxable = create(:product, tax_category: tax_category, price: 11.0)
+            order.contents.add(taxable.master, 2)
+          end
+        end
+
+        it "successfully applies the promo" do
+          # 3 * (22 + 2.2)
+          expect(order.total.to_f).to eq(72.6)
+          coupon = described_class.new(order)
+          coupon.apply
+          expect(coupon.success).to be_present
+          # 3 * ( (22 - 10) + 1.2)
+          expect(order.reload.total).to eq(39.6)
+          expect(order.additional_tax_total).to eq(3.6)
+        end
+      end
+
+      context "and multiple quantity per line item" do
+        before(:each) do
+          twnty_off = create(:friendly_promotion, name: "promo", code: "20off")
+          twnty_off_calc = SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 20)
+          SolidusFriendlyPromotions::Actions::AdjustLineItem.create(promotion: twnty_off,
+            calculator: twnty_off_calc)
+
+          order.coupon_code = "20off"
+
+          3.times do |_i|
+            taxable = create(:product, tax_category: tax_category, price: 10.0)
+            order.contents.add(taxable.master, 2)
+          end
+        end
+
+        it "successfully applies the promo" do
+          # 3 * ((2 * 10) + 2.0)
+          expect(order.total.to_f).to eq(66)
+          coupon = described_class.new(order)
+          coupon.apply
+          expect(coupon.success).to be_present
+          # 0
+          expect(order.reload.total).to eq(0)
+          expect(order.additional_tax_total).to eq(0)
+        end
+      end
+    end
+  end
+
+  context "removing a coupon code from an order" do
+    let!(:promotion) { promotion_code.promotion }
+    let(:promotion_code) { create(:friendly_promotion_code, value: "10off") }
+    let!(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.create(promotion: promotion, calculator: calculator) }
+    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
+    let(:order) { create(:order_with_line_items, line_items_count: 3) }
+
+    context "with an already applied coupon" do
+      before do
+        order.coupon_code = "10off"
+        subject.apply
+        order.reload
+        expect(order.total).to eq(100)
+      end
+
+      it "successfully removes the coupon code from the order" do
+        subject.remove
+        expect(subject.error).to eq nil
+        expect(subject.success).to eq I18n.t("spree.coupon_code_removed")
+        expect(order.reload.total).to eq(130)
+      end
+    end
+
+    context "with a coupon code not applied to an order" do
+      before do
+        order.coupon_code = "10off"
+        expect(order.total).to eq(130)
+      end
+
+      it "returns an error" do
+        subject.remove
+        expect(subject.success).to eq nil
+        expect(subject.error).to eq I18n.t("spree.coupon_code_not_present")
+        expect(order.reload.total).to eq(130)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the service object that deals with a coupon code being added to the order while in checkout. It checks the coupon code's promotion's eligibility and, depending on eligibilty, connects it to the order or not.

This is where we use the eligibility results class, and I'm not sure I'm loving the API. I think we want to iterate on that for a bit more.