### PR TITLE
Do not call Spree::PromotionHandler::Shipping when SFP is active

### DIFF
--- a/app/decorators/models/solidus_friendly_promotions/order_decorator.rb
+++ b/app/decorators/models/solidus_friendly_promotions/order_decorator.rb
@@ -29,6 +29,14 @@ module SolidusFriendlyPromotions
       shipments.each(&:reset_current_discounts)
     end
 
+    def apply_shipping_promotions
+      if Spree::Config.promotion_adjuster_class <= SolidusFriendlyPromotions::OrderDiscounter
+        recalculate
+      else
+        super
+      end
+    end
+
     Spree::Order.prepend self
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -33,4 +33,27 @@ RSpec.describe Spree::Order do
       expect { subject }.to change { SolidusFriendlyPromotions::OrderPromotion.count }.from(1).to(0)
     end
   end
+
+  describe "#apply_shipping_promotions" do
+    let(:order) { build(:order) }
+    subject { order.apply_shipping_promotions }
+
+    it "does not call Spree::PromotionHandler::Shipping" do
+      expect(Spree::PromotionHandler::Shipping).not_to receive(:new)
+      subject
+    end
+
+    context "if solidus_friendly_promotions is not active" do
+      around do |example|
+        Spree::Config.promotion_adjuster_class = Spree::Promotion::OrderAdjustmentsRecalculator
+        example.run
+        Spree::Config.promotion_adjuster_class = SolidusFriendlyPromotions::OrderDiscounter
+      end
+
+      it "does call the promotion handler shipping" do
+        expect(Spree::PromotionHandler::Shipping).to receive(:new).and_call_original
+        subject
+      end
+    end
+  end
 end


### PR DESCRIPTION
SolidusFriendlyPromotions does not need this call, and it could be actively harmful if SFP is active.