### PR TITLE
Promo Migrator: Ignore missing rules and actions

### DIFF
--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -28,10 +28,10 @@ module SolidusFriendlyPromotions
           generate_new_promotion_rules(old_promotion_rule)
         end
         new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
-          generate_new_promotion_actions(old_promotion_action).tap do |new_promotion_action|
+          generate_new_promotion_actions(old_promotion_action)&.tap do |new_promotion_action|
             new_promotion_action.original_promotion_action = old_promotion_action
           end
-        end
+        end.compact
         new_promotion.save!
         copy_promotion_code_batches(new_promotion)
         copy_promotion_codes(new_promotion)
@@ -79,7 +79,7 @@ module SolidusFriendlyPromotions
       promo_action_config = promotion_map[:actions][old_promotion_action.class]
       if promo_action_config.nil?
         puts("#{old_promotion_action.class} is not supported")
-        return []
+        return nil
       end
       promo_action_config.call(old_promotion_action)
     end

--- a/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
@@ -51,4 +51,19 @@ RSpec.describe SolidusFriendlyPromotions::PromotionMigrator do
       expect(promotion_code_batch.base_code).to eq("DISNEY4LIFE")
     end
   end
+
+  context "if our rules and actions are missing from the promotion map" do
+    let(:promotion_map) do
+      {
+        rules: {},
+        actions: {}
+      }
+    end
+
+    it "still creates the promotion, but without rules or actions" do
+      subject
+      expect(Spree::Promotion.count).not_to be_zero
+      expect(SolidusFriendlyPromotions::Promotion.count).to eq(Spree::Promotion.count)
+    end
+  end
 end


### PR DESCRIPTION
If the promotion migrator's promotion map does not include the promotion actions or rules from the original Spree promotions, don't fail with an error, and still create all the promotions.