### PR TITLE
Add migrate order promotions rake task

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -51,16 +51,19 @@ Spree::Config.promotion_adjuster_class = "SolidusFriendlyPromotions::OrderDiscou
 
 From a user's perspective, your promotions should work as before.
 
-Before you create new promotions, migrate the adjustments in your database:
+Before you create new promotions, migrate the adjustments and order promotions in your database:
 
 ```rb
 bundle exec rails solidus_friendly_promotions:migrate_adjustments:up
+bundle exec rails solidus_friendly_promotions:migrate_order_promotions:up
+
 ```
 
 Check your `spree_adjustments` table for correctness. If things went wrong, you should be able to roll back with
 
 ```rb
 bundle exec rails solidus_friendly_promotions:migrate_adjustments:down
+bundle exec rails solidus_friendly_promotions:migrate_order_promotions:down
 ```
 
 Both of these tasks only work if every promotion and promotion action have an equivalent in SolidusFrienndlyPromotions. Promotion Actions are connected to their originals using the `SolidusFriendlyPromotions#original_promotion_action_id`, Promotions are connected to their originals using the  `SolidusFriendlyPromotions#original_promotion_id`.

--- a/lib/solidus_friendly_promotions/migrate_order_promotions.rb
+++ b/lib/solidus_friendly_promotions/migrate_order_promotions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class MigrateOrderPromotions
+    class << self
+      def up
+        Spree::OrderPromotion.all.each do |order_promotion|
+          friendly_promotion = SolidusFriendlyPromotions::Promotion.find_by!(original_promotion_id: order_promotion.promotion.id)
+          friendly_promotion_code = friendly_promotion.codes.find_by(value: order_promotion.promotion_code.value)
+          SolidusFriendlyPromotions::OrderPromotion.find_or_create_by!(order: order_promotion.order,
+            promotion: friendly_promotion,
+            promotion_code: friendly_promotion_code)
+          order_promotion.destroy!
+        end
+      end
+
+      def down
+        SolidusFriendlyPromotions::OrderPromotion.all.each do |friendly_order_promotion|
+          spree_promotion = friendly_order_promotion.promotion.original_promotion
+          spree_promotion_code = spree_promotion.promotion_codes.find_by(value: friendly_order_promotion.promotion_code.value)
+          Spree::OrderPromotion.find_or_create_by!(order: friendly_order_promotion.order,
+            promotion: spree_promotion,
+            promotion_code: spree_promotion_code)
+          friendly_order_promotion.destroy!
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/solidus_friendly_promotions/migrate_order_promotions.rake
+++ b/lib/tasks/solidus_friendly_promotions/migrate_order_promotions.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :solidus_friendly_promotions do
+  namespace :migrate_order_promotions do
+    desc "Migrate order promotions from Spree::OrderPromotion sources to SolidusFriendlyPromotions::FriendlyOrderPromotion sources"
+    task up: :environment do
+      require "solidus_friendly_promotions/migrate_order_promotions"
+      SolidusFriendlyPromotions::MigrateOrderPromotions.up
+    end
+
+    desc "Migrate order promotions from SolidusFriendlyPromotions::FriendlyOrderPromotion sources to Spree::OrderPromotion sources"
+    task down: :environment do
+      require "solidus_friendly_promotions/migrate_order_promotions"
+      SolidusFriendlyPromotions::MigrateOrderPromotions.down
+    end
+  end
+end

--- a/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "solidus_friendly_promotions/promotion_migrator"
+require "solidus_friendly_promotions/promotion_map"
+require "solidus_friendly_promotions/migrate_order_promotions"
+
+RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
+  let(:promotion) { create(:promotion, :with_adjustable_action) }
+  let(:order) { create(:order_with_line_items) }
+  let(:line_item) { order.line_items.first }
+  let(:promotion_code) { create(:promotion_code, promotion: promotion) }
+
+  before do
+    order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
+    SolidusFriendlyPromotions::PromotionMigrator.new(
+      SolidusFriendlyPromotions::PROMOTION_MAP
+    ).call
+  end
+
+  describe ".up" do
+    subject { described_class.up }
+
+    it "migrates our order promotion" do
+      expect { subject }.to change {
+        Spree::OrderPromotion.count
+      }.from(1).to(0)
+    end
+
+    it "creates our order promotion" do
+      expect { subject }.to change {
+        SolidusFriendlyPromotions::OrderPromotion.count
+      }.from(0).to(1)
+
+      order_promotion = SolidusFriendlyPromotions::OrderPromotion.first
+      expect(order_promotion.order).to eq(order)
+      expect(order_promotion.promotion).to eq(SolidusFriendlyPromotions::Promotion.first)
+      expect(order_promotion.promotion_code.value).to eq(promotion_code.value)
+    end
+  end
+
+  describe ".down" do
+    subject { described_class.down }
+
+    before do
+      described_class.up
+    end
+
+    it "migrates our order promotion" do
+      expect { subject }.to change {
+        Spree::OrderPromotion.count
+      }.from(0).to(1)
+
+      order_promotion = Spree::OrderPromotion.first
+      expect(order_promotion.order).to eq(order)
+      expect(order_promotion.promotion).to eq(promotion)
+      expect(order_promotion.promotion_code).to eq(promotion_code)
+    end
+
+    it "creates our order promotion" do
+      expect { subject }.to change {
+        SolidusFriendlyPromotions::OrderPromotion.count
+      }.from(1).to(0)
+    end
+  end
+end


### PR DESCRIPTION
There is code to migrate promotions on the fly and create these automatically. However, it will be nice to eventually remove all of the old promotions and all of their references.

Co-Authored-By: mamhoff@gmail.com