### PR TITLE
Refactor order promotions migrator

### DIFF
--- a/lib/solidus_friendly_promotions/migrate_order_promotions.rb
+++ b/lib/solidus_friendly_promotions/migrate_order_promotions.rb
@@ -4,29 +4,69 @@ module SolidusFriendlyPromotions
   class MigrateOrderPromotions
     class << self
       def up
-        Spree::OrderPromotion.all.each do |order_promotion|
-          friendly_promotion = SolidusFriendlyPromotions::Promotion.find_by!(original_promotion_id: order_promotion.promotion.id)
-          if order_promotion.promotion_code
-            friendly_promotion_code = friendly_promotion.codes.find_by(value: order_promotion.promotion_code.value)
-          end
-          SolidusFriendlyPromotions::OrderPromotion.find_or_create_by!(order: order_promotion.order,
-            promotion: friendly_promotion,
-            promotion_code: friendly_promotion_code)
-          order_promotion.destroy!
-        end
+        sql = <<~SQL
+          INSERT INTO friendly_order_promotions (
+            order_id,
+            promotion_id,
+            promotion_code_id,
+            created_at,
+            updated_at
+          )
+          SELECT
+            spree_orders_promotions.order_id AS order_id,
+            friendly_promotions.id AS promotion_id,
+            friendly_promotion_codes.id AS promotion_code_id,
+            spree_orders_promotions.created_at,
+            spree_orders_promotions.updated_at
+          FROM spree_orders_promotions
+            INNER JOIN spree_promotions ON spree_orders_promotions.promotion_id = spree_promotions.id
+            INNER JOIN friendly_promotions ON spree_promotions.id = friendly_promotions.original_promotion_id
+            LEFT OUTER JOIN spree_promotion_codes ON spree_orders_promotions.promotion_code_id = spree_promotion_codes.id
+            LEFT OUTER JOIN friendly_promotion_codes ON spree_promotion_codes.value = friendly_promotion_codes.value
+          WHERE NOT EXISTS (
+            SELECT NULL
+            FROM friendly_order_promotions
+            WHERE friendly_order_promotions.order_id = order_id
+              AND (friendly_order_promotions.promotion_code_id = promotion_code_id OR promotion_code_id IS NULL)
+              AND friendly_order_promotions.promotion_id = promotion_id
+          );
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+
+        Spree::OrderPromotion.delete_all
       end
 
       def down
-        SolidusFriendlyPromotions::OrderPromotion.all.each do |friendly_order_promotion|
-          spree_promotion = friendly_order_promotion.promotion.original_promotion
-          if friendly_order_promotion.promotion_code
-            spree_promotion_code = spree_promotion.promotion_codes.find_by(value: friendly_order_promotion.promotion_code.value)
-          end
-          Spree::OrderPromotion.find_or_create_by!(order: friendly_order_promotion.order,
-            promotion: spree_promotion,
-            promotion_code: spree_promotion_code)
-          friendly_order_promotion.destroy!
-        end
+        sql = <<~SQL
+          INSERT INTO spree_orders_promotions (
+            order_id,
+            promotion_id,
+            promotion_code_id,
+            created_at,
+            updated_at
+          )
+          SELECT
+            friendly_order_promotions.order_id AS order_id,
+            spree_promotions.id AS promotion_id,
+            spree_promotion_codes.id AS promotion_code_id,
+            friendly_order_promotions.created_at,
+            friendly_order_promotions.updated_at
+          FROM friendly_order_promotions
+            INNER JOIN friendly_promotions ON friendly_order_promotions.promotion_id = friendly_promotions.id
+            INNER JOIN spree_promotions ON spree_promotions.id = friendly_promotions.original_promotion_id
+            LEFT OUTER JOIN friendly_promotion_codes ON friendly_order_promotions.promotion_code_id = friendly_promotion_codes.id
+            LEFT OUTER JOIN spree_promotion_codes ON spree_promotion_codes.value = friendly_promotion_codes.value
+          WHERE NOT EXISTS (
+            SELECT NULL
+            FROM spree_orders_promotions
+            WHERE spree_orders_promotions.order_id = order_id
+              AND (spree_orders_promotions.promotion_code_id = promotion_code_id OR promotion_code_id IS NULL)
+              AND spree_orders_promotions.promotion_id = promotion_id
+          );
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+
+        SolidusFriendlyPromotions::OrderPromotion.delete_all
       end
     end
   end

--- a/lib/solidus_friendly_promotions/migrate_order_promotions.rb
+++ b/lib/solidus_friendly_promotions/migrate_order_promotions.rb
@@ -6,7 +6,9 @@ module SolidusFriendlyPromotions
       def up
         Spree::OrderPromotion.all.each do |order_promotion|
           friendly_promotion = SolidusFriendlyPromotions::Promotion.find_by!(original_promotion_id: order_promotion.promotion.id)
-          friendly_promotion_code = friendly_promotion.codes.find_by(value: order_promotion.promotion_code.value)
+          if order_promotion.promotion_code
+            friendly_promotion_code = friendly_promotion.codes.find_by(value: order_promotion.promotion_code.value)
+          end
           SolidusFriendlyPromotions::OrderPromotion.find_or_create_by!(order: order_promotion.order,
             promotion: friendly_promotion,
             promotion_code: friendly_promotion_code)
@@ -17,7 +19,9 @@ module SolidusFriendlyPromotions
       def down
         SolidusFriendlyPromotions::OrderPromotion.all.each do |friendly_order_promotion|
           spree_promotion = friendly_order_promotion.promotion.original_promotion
-          spree_promotion_code = spree_promotion.promotion_codes.find_by(value: friendly_order_promotion.promotion_code.value)
+          if friendly_order_promotion.promotion_code
+            spree_promotion_code = spree_promotion.promotion_codes.find_by(value: friendly_order_promotion.promotion_code.value)
+          end
           Spree::OrderPromotion.find_or_create_by!(order: friendly_order_promotion.order,
             promotion: spree_promotion,
             promotion_code: spree_promotion_code)

--- a/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
   describe ".up" do
     subject { described_class.up }
 
-    it "migrates our order promotion" do
+    it "deletes the spree order promotion" do
       expect { subject }.to change {
         Spree::OrderPromotion.count
       }.from(1).to(0)
@@ -41,7 +41,7 @@ RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
     context "with an order promotion without a promotion code" do
       let!(:order_promotion) { order.order_promotions.create!(promotion: promotion) }
 
-      it "migrates our order promotion" do
+      it "deletes the spree order promotion" do
         expect { subject }.to change {
           Spree::OrderPromotion.count
         }.from(1).to(0)
@@ -57,6 +57,57 @@ RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
         expect(order_promotion.promotion).to eq(SolidusFriendlyPromotions::Promotion.first)
         expect(order_promotion.promotion_code).to be nil
       end
+
+      context "if the order promotion already exists" do
+        before do
+          order.friendly_order_promotions.create!(
+            promotion: SolidusFriendlyPromotions::Promotion.first,
+            promotion_code: nil
+          )
+        end
+
+        it "deletes the friendly order promotion" do
+          expect { subject }.to change {
+            Spree::OrderPromotion.count
+          }.from(1).to(0)
+        end
+
+        it "does not create the already existing spree promotion code" do
+          expect { subject }.not_to change {
+            SolidusFriendlyPromotions::OrderPromotion.count
+          }.from(1)
+
+          order_promotion = SolidusFriendlyPromotions::OrderPromotion.last
+          expect(order_promotion.order).to eq(order)
+          expect(order_promotion.promotion).to eq(SolidusFriendlyPromotions::Promotion.first)
+          expect(order_promotion.promotion_code).to be nil
+        end
+      end
+    end
+
+    context "if the order promotion already exists" do
+      before do
+        order.friendly_order_promotions.create(
+          promotion: SolidusFriendlyPromotions::Promotion.first,
+          promotion_code: SolidusFriendlyPromotions::PromotionCode.first
+        )
+      end
+      it "deletes the spree order promotion" do
+        expect { subject }.to change {
+          Spree::OrderPromotion.count
+        }.from(1).to(0)
+      end
+
+      it "does not create the already existing friendly promotion code" do
+        expect { subject }.not_to change {
+          SolidusFriendlyPromotions::OrderPromotion.count
+        }.from(1)
+
+        order_promotion = SolidusFriendlyPromotions::OrderPromotion.first
+        expect(order_promotion.order).to eq(order)
+        expect(order_promotion.promotion).to eq(SolidusFriendlyPromotions::Promotion.first)
+        expect(order_promotion.promotion_code).to eq(SolidusFriendlyPromotions::PromotionCode.first)
+      end
     end
   end
 
@@ -67,7 +118,7 @@ RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
       described_class.up
     end
 
-    it "migrates our order promotion" do
+    it "creates the spree order promotion" do
       expect { subject }.to change {
         Spree::OrderPromotion.count
       }.from(0).to(1)
@@ -101,6 +152,57 @@ RSpec.describe SolidusFriendlyPromotions::MigrateOrderPromotions do
         expect { subject }.to change {
           SolidusFriendlyPromotions::OrderPromotion.count
         }.from(1).to(0)
+      end
+
+      context "if the order promotion already exists" do
+        before do
+          order.order_promotions.create!(
+            promotion: promotion,
+            promotion_code: nil
+          )
+        end
+
+        it "deletes the friendly order promotion" do
+          expect { subject }.to change {
+            SolidusFriendlyPromotions::OrderPromotion.count
+          }.from(1).to(0)
+        end
+
+        it "does not create the already existing spree promotion code" do
+          expect { subject }.not_to change {
+            Spree::OrderPromotion.count
+          }.from(1)
+
+          order_promotion = Spree::OrderPromotion.last
+          expect(order_promotion.order).to eq(order)
+          expect(order_promotion.promotion).to eq(promotion)
+          expect(order_promotion.promotion_code).to be nil
+        end
+      end
+    end
+
+    context "if the order promotion already exists" do
+      before do
+        order.order_promotions.create(
+          promotion: promotion,
+          promotion_code: promotion_code
+        )
+      end
+      it "deletes the spree order promotion" do
+        expect { subject }.to change {
+          SolidusFriendlyPromotions::OrderPromotion.count
+        }.from(1).to(0)
+      end
+
+      it "does not create the already existing friendly promotion code" do
+        expect { subject }.not_to change {
+          Spree::OrderPromotion.count
+        }.from(1)
+
+        order_promotion = Spree::OrderPromotion.first
+        expect(order_promotion.order).to eq(order)
+        expect(order_promotion.promotion).to eq(promotion)
+        expect(order_promotion.promotion_code).to eq(promotion_code)
       end
     end
   end


### PR DESCRIPTION
Adds a specs for order promotions without promotion codes as well as speeds the whole thing up using SQL magic.