### PR TITLE
Ignore shipping rates that have no cost

### DIFF
--- a/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_discounter.rb
@@ -49,7 +49,7 @@ module SolidusFriendlyPromotions
     end
 
     def adjust_shipping_rates(promotions)
-      order.shipments.flat_map(&:shipping_rates).map do |rate|
+      order.shipments.flat_map(&:shipping_rates).select(&:cost).map do |rate|
         discounts = generate_discounts(promotions, rate)
         chosen_item_discounts = SolidusFriendlyPromotions.config.discount_chooser_class.new(rate).call(discounts)
         [rate, chosen_item_discounts]

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_discounter_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionDiscounter do
     end
   end
 
+  describe "discounting orders" do
+    let(:shirt) { create(:product, name: "Shirt") }
+    let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}]) }
+    let!(:promotion) { create(:friendly_promotion, :with_free_shipping, name: "20% off Shirts", apply_automatically: true) }
+    let(:promotions) { [promotion] }
+    let(:discounter) { described_class.new(order, promotions) }
+
+    subject { discounter.call }
+
+    before do
+      order.shipments.first.shipping_rates.first.update!(cost: nil)
+    end
+
+    it "does not blow up if the shipping rate cost is nil" do
+      expect { subject }.not_to raise_exception
+    end
+  end
+
   describe "collecting eligibility results" do
     let(:shirt) { create(:product, name: "Shirt") }
     let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}]) }


### PR DESCRIPTION
If a shipping rate happens to have a nil cost, then don't try to create a discount for it.