### PR TITLE
Add PromotionHandler::Page

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_handler/page.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/page.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module PromotionHandler
+    class Page
+      attr_reader :order, :path
+
+      def initialize(order, path)
+        @order = order
+        @path = path.gsub(/\A\//, "")
+      end
+
+      def activate
+        if promotion
+          active_promotions = SolidusFriendlyPromotions::PromotionLoader.new(order: order).call
+          SolidusFriendlyPromotions::FriendlyPromotionDiscounter.new(
+            order,
+            active_promotions + [promotion],
+            collect_eligibility_results: true
+          ).call
+          if promotion.eligibility_results.success?
+            order.friendly_promotions << promotion
+            order.recalculate
+          end
+        end
+      end
+
+      private
+
+      def promotion
+        @promotion ||= SolidusFriendlyPromotions::Promotion.active.find_by(path: path)
+      end
+    end
+  end
+end

--- a/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Page, type: :model do
+  subject { described_class.new(order, path).activate }
+
+  let(:order) { create(:order_with_line_items, line_items_count: 1) }
+  let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, name: "10% off", path: "10off") }
+  let(:path) { "10off" }
+
+  it "activates at the right path" do
+    expect(order.line_item_adjustments.count).to eq(0)
+    subject
+    expect(order.line_item_adjustments.count).to eq(1)
+  end
+
+  context "when promotion is expired" do
+    before do
+      promotion.update(
+        starts_at: 1.week.ago,
+        expires_at: 1.day.ago
+      )
+    end
+
+    it "is not activated" do
+      expect(order.line_item_adjustments.count).to eq(0)
+      subject
+      expect(order.line_item_adjustments.count).to eq(0)
+    end
+  end
+
+  context "with a wrong path" do
+    let(:path) { "wrongpath" }
+    it "does not activate at the wrong path" do
+      expect(order.line_item_adjustments.count).to eq(0)
+      subject
+      expect(order.line_item_adjustments.count).to eq(0)
+    end
+  end
+
+  context "when promotion is not eligible" do
+    let(:impossible_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+    before do
+      promotion.rules << impossible_rule
+    end
+
+    it "is not applied" do
+      expect { subject }.not_to change { order.line_item_adjustments.count }
+    end
+
+    it "does not connect the promotion to the order" do
+      expect { subject }.not_to change { order.friendly_order_promotions.count }
+    end
+  end
+end


### PR DESCRIPTION
This is modeled after `Spree::PromotionHandler::Page`. One could add error handling like in the
`SolidusFriendlyPromotions::PromotionHandler::Coupon`, but that is not implemented the base version either.