### PR TITLE
Add a null promotion handler

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_handler/null.rb
+++ b/app/models/solidus_friendly_promotions/promotion_handler/null.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  module PromotionHandler
+    # We handle shipping promotions just like other promotions, so we don't need a
+    # special promotion handler for shipping. However, Solidus wants us to implement one.
+    # This is what this class is for.
+    class Null
+      attr_reader :order
+      attr_accessor :error, :success
+
+      def initialize(order)
+        @order = order
+      end
+
+      def activate
+      end
+    end
+  end
+end

--- a/spec/models/solidus_friendly_promotions/promotion_handler/null_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/null_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Null do
+  let(:order) { double }
+
+  subject { described_class.new(order) }
+
+  it { is_expected.to respond_to(:order) }
+  it { is_expected.to respond_to(:error) }
+  it { is_expected.to respond_to(:success) }
+  it { is_expected.to respond_to(:activate) }
+end


### PR DESCRIPTION
This class is useful for satisfying Solidus' need for a shipping promotion handler. With SolidusFriendlyPromotions, shipping promotions are handled just like other promotions, so we don't need to do anything here.

See https://github.com/solidusio/solidus/pull/5466