### PR TITLE
Use Remix icons if Solidus' admin_updated_navbar is enabled

### DIFF
--- a/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
+++ b/lib/generators/solidus_friendly_promotions/install/templates/initializer.rb
@@ -17,7 +17,7 @@ Spree::Backend::Config.configure do |config|
     if item.respond_to?(:children)
       Spree::BackendConfiguration::MenuItem.new(
         label: :promotions,
-        icon: "bullhorn",
+        icon: config.admin_updated_navbar ? "ri-megaphone-line" : "bullhorn",
         condition: -> { can?(:admin, SolidusFriendlyPromotions::Promotion) },
         url: -> { SolidusFriendlyPromotions::Engine.routes.url_helpers.admin_promotions_path },
         data_hook: :admin_promotion_sub_tabs,


### PR DESCRIPTION
Solidus 2.4 introduced a new admin navbar with new icons that can be enabled in the settings. Adopt to that.

<img width="250px" alt="" src="https://github.com/friendlycart/solidus_friendly_promotions/assets/42868/13bfdcd6-8d84-4f4d-8f06-cf4646b3b7f0">
