### PR TITLE
Coupon Promo Handler: Fix flaky spec

### DIFF
--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -441,11 +441,15 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
     it "is unsuccessful with multiple errors" do
       subject
       expect(handler.success).to be nil
-      expect(handler.error).to eq("You need to add an applicable product before applying this coupon code.")
-      expect(handler.errors).to eq([
+      # Promotion rules are not ordered, so it can be either of these errors.
+      expect(handler.error).to be_in([
         "You need to add an applicable product before applying this coupon code.",
         "This coupon code could not be applied to the cart at this time."
       ])
+      expect(handler.errors).to contain_exactly(
+        "You need to add an applicable product before applying this coupon code.",
+        "This coupon code could not be applied to the cart at this time."
+      )
     end
   end
 end


### PR DESCRIPTION
Promotion Rules are not ordered, so the database might return them in any order. This adjusts the spec accordingly (especially Postgres returns them in a different order than expected sometimes).

See https://app.circleci.com/pipelines/github/friendlycart/solidus_friendly_promotions/295/workflows/f5d74528-a1f5-4ec8-9eb1-3cf7deda4d2d/jobs/957