### PR TITLE
Refactor UI

### DIFF
--- a/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
+++ b/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
@@ -8,6 +8,7 @@ module SolidusFriendlyPromotions
       before_action :validate_promotion_action_type, only: [:create, :edit]
 
       def new
+        @level = params[:level] || :line_item
         if params.dig(:promotion_action, :type)
           validate_promotion_action_type
           @promotion_action = @promotion.actions.build(type: @promotion_action_type)

--- a/app/helpers/solidus_friendly_promotions/admin/promotion_actions_helper.rb
+++ b/app/helpers/solidus_friendly_promotions/admin/promotion_actions_helper.rb
@@ -9,8 +9,8 @@ module SolidusFriendlyPromotions
         options_for_select(options, promotion_action.calculator_type.to_s)
       end
 
-      def options_for_promotion_action_types(promotion_action)
-        actions = SolidusFriendlyPromotions.config.actions
+      def options_for_promotion_action_types(promotion_action, level)
+        actions = SolidusFriendlyPromotions.config.actions.select { _1.new.level == level.to_sym }
         options = actions.map { |action| [action.model_name.human, action.name] }
         options_for_select(options, promotion_action&.type&.to_s)
       end

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/_type_select.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/_type_select.html.erb
@@ -3,7 +3,7 @@
   <%= admin_hint t('solidus_friendly_promotions.adjustment_type'), t(:promotions, scope: [:solidus_friendly_promotions, :hints, "solidus_friendly_promotions/calculator"]) %>
   <%=
     form.select :type,
-      options_for_promotion_action_types(form.object),
+      options_for_promotion_action_types(form.object, level),
       {
         include_blank: t(:choose_promotion_action, scope: 'solidus_friendly_promotions')
       },

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/actions/_create_discounted_item.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/actions/_create_discounted_item.html.erb
@@ -2,6 +2,8 @@
   <div class="field">
     <%= form.label :preferred_variant_id %>
     <%= form.text_field :preferred_variant_id, class: "variant_autocomplete fullwidth" %>
+  </div>
+  <div class="field">
     <%= form.label :preferred_quantity %>
     <%= form.number_field :preferred_quantity, class: "fullwidth" %>
   </div>

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/new.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/new.html.erb
@@ -1,8 +1,8 @@
-<%= turbo_frame_tag @promotion, "new_promotion_action" do %>
+<%= turbo_frame_tag @promotion, "new_#{@level}_promotion_action" do %>
   <div class="promotion_action promotion-block">
     <h6 class='promotion-title'> <%= t(:add_action, scope: :solidus_friendly_promotions) %></h6>
     <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.edit_admin_promotion_path(@promotion), class: 'delete' %>
-    <%= render 'type_select' %>
+    <%= render 'type_select', level: @level %>
     <% if @promotion_action.respond_to?(:calculator) %>
       <%= render 'calculator_select', path: solidus_friendly_promotions.new_admin_promotion_promotion_action_path(@promotion), promotion_action: @promotion_action %>
       <% if @promotion_action.calculator %>

--- a/app/views/solidus_friendly_promotions/admin/promotions/edit.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/edit.html.erb
@@ -28,48 +28,34 @@
   <% end %>
 <% end %>
 
-
-<fieldset>
-  <legend align="center"><%= t(:order_rules, scope: :solidus_friendly_promotions) %></legend>
-
-  <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_rules_by_level(@promotion, :order), locals: { level: :order } %>
-
-  <%= turbo_frame_tag @promotion, "new_order_promotion_rule" do %>
-    <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion, level: :order), class: 'btn btn-secondary' %>
-  <% end %>
-</fieldset>
-
-<div class="row">
-  <div class="col-12">
-    <%= turbo_frame_tag @promotion, "new_promotion_action" do %>
-      <%= link_to t(:add_action, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_action_path(@promotion), class: 'btn btn-secondary' %>
-    <% end %>
-  </div>
-</div>
-
 <div class="row">
   <% [:order, :line_item, :shipment].each do |level| %>
-    <% if promotion_actions_by_level(@promotion, level).any? %>
-      <div class="col-<%= level == :order ? 12 : 6 %>">
-        <fieldset>
-          <legend align="center"><%= t("#{level}_actions", scope: :solidus_friendly_promotions) %></legend>
+  <div class="col-6">
+      <fieldset>
+        <legend align="center"><%= t("#{level}_rules", scope: :solidus_friendly_promotions) %></legend>
 
-          <%= render partial: 'solidus_friendly_promotions/admin/promotion_actions/promotion_action', collection: promotion_actions_by_level(@promotion, level), locals: {} %>
-        </fieldset>
-      </div>
-      <% if level != :order %>
-        <div class="col-6">
-          <fieldset>
-            <legend align="center"><%= t("#{level}_rules", scope: :solidus_friendly_promotions) %></legend>
+        <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_rules_by_level(@promotion, level), locals: { level: level } %>
 
-            <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_rules_by_level(@promotion, level), locals: { level: level } %>
+        <%= turbo_frame_tag @promotion, "new_#{level}_promotion_rule" do %>
+          <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion, level: level), class: 'btn btn-secondary' %>
+        <% end %>
+      </fieldset>
+    </div>
+    <div class="col-6">
+      <fieldset>
+        <legend align="center"><%= t("#{level}_actions", scope: :solidus_friendly_promotions) %></legend>
 
-            <%= turbo_frame_tag @promotion, "new_#{level}_promotion_rule" do %>
-              <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion, level: level), class: 'btn btn-secondary' %>
+        <%= render partial: 'solidus_friendly_promotions/admin/promotion_actions/promotion_action', collection: promotion_actions_by_level(@promotion, level), locals: {} %>
+
+        <div class="row">
+          <div class="col-12">
+            <%= turbo_frame_tag @promotion, "new_#{level}_promotion_action" do %>
+              <%= link_to t(:add_action, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_action_path(@promotion, level: level), class: 'btn btn-secondary' %>
             <% end %>
-          </fieldset>
+          </div>
         </div>
-      <% end %>
-    <% end %>
+
+      </fieldset>
+    </div>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,7 @@ en:
         description: Creates a promotion credit on matching shipments
       solidus_friendly_promotions/actions/create_discounted_item:
         description: Creates a discounted item
+        preferred_quantity: Quantity per applicable line item quantity
       solidus_friendly_promotions/rules/first_order:
         description: Must be the customer's first order
       solidus_friendly_promotions/rules/first_repeat_purchase_since:

--- a/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
+++ b/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Promotions admin", type: :system do
         expect(find("#promotion_rule_preferred_amount").value).to eq("300.00")
       end
 
-      within("#new_promotion_action_promotion_#{promotion.id}") do
+      within("#new_line_item_promotion_action_promotion_#{promotion.id}") do
         click_link("New Action")
         select("Discount matching line items", from: "Type")
         select("Flat Rate", from: "Calculator type")


### PR DESCRIPTION
There has been consistent feedback that people would like to see promotion rules on the left and actions on the right, like in legacy Solidus.

We also can't hide line item rules anymore when we have order-level actions, because the order-level rules do need to find applicable line items as well (for example, to determine the needed quantity of a newly created item).


Before:
![grafik](https://github.com/friendlycart/solidus_friendly_promotions/assets/703401/3801595d-af3f-4820-a19d-83ce0805df50)

After:
![grafik](https://github.com/friendlycart/solidus_friendly_promotions/assets/703401/3e0f08d9-ca52-405d-aae8-76dcafd43f7b)