### PR TITLE
Refactor: Extract `Promotion#applicable_line_items`

### DIFF
--- a/app/models/solidus_friendly_promotions/actions/adjust_line_item_quantity_groups.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_line_item_quantity_groups.rb
@@ -58,7 +58,7 @@ module SolidusFriendlyPromotions
         adjustment_amount = adjustment_amount.abs
 
         order = line_item.order
-        line_items = actionable_line_items(order)
+        line_items = promotion.applicable_line_items(order)
 
         item_units = line_items.sort_by do |line_item|
           [-line_item.quantity, line_item.id]
@@ -77,14 +77,6 @@ module SolidusFriendlyPromotions
       end
 
       private
-
-      def actionable_line_items(order)
-        order.discountable_line_items.select do |item|
-          promotion.rules.select do |rule|
-            rule.applicable?(item)
-          end.all? { |rule| rule.eligible?(item) }
-        end
-      end
 
       ##
       # Used specifically for PercentOnLineItem calculator. That calculator uses

--- a/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
+++ b/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
@@ -16,21 +16,13 @@ module SolidusFriendlyPromotions
         return 0 unless line_item
         return 0 unless preferred_currency.casecmp(line_item.currency).zero?
 
-        distributable_line_items = eligible_line_items(line_item.order)
+        distributable_line_items = calculable.promotion.applicable_line_items(line_item.order)
         return 0 unless line_item.in?(distributable_line_items)
 
         DistributedAmountsHandler.new(
           distributable_line_items,
           preferred_amount
         ).amount(line_item)
-      end
-
-      private
-
-      def eligible_line_items(order)
-        order.discountable_line_items.select do |line_item|
-          calculable.promotion.eligible_by_applicable_rules?(line_item)
-        end
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -155,6 +155,12 @@ module SolidusFriendlyPromotions
       end.all?
     end
 
+    def applicable_line_items(order)
+      order.discountable_line_items.select do |line_item|
+        eligible_by_applicable_rules?(line_item)
+      end
+    end
+
     private
 
     def apply_automatically_disallowed_with_paths

--- a/app/models/solidus_friendly_promotions/rules/minimum_quantity.rb
+++ b/app/models/solidus_friendly_promotions/rules/minimum_quantity.rb
@@ -27,13 +27,7 @@ module SolidusFriendlyPromotions
       # @param order [Spree::Order] the order we want to check eligibility on
       # @return [Boolean] true if promotion is eligible, false otherwise
       def eligible?(order)
-        applicable_line_items = order.line_items.select do |line_item|
-          promotion.rules.select do |rule|
-            rule.applicable?(line_item)
-          end.all? { _1.eligible?(line_item) }
-        end
-
-        if applicable_line_items.sum(&:quantity) < preferred_minimum_quantity
+        if promotion.applicable_line_items(order).sum(&:quantity) < preferred_minimum_quantity
           eligibility_errors.add(
             :base,
             eligibility_error_message(:quantity_less_than_minimum, count: preferred_minimum_quantity),


### PR DESCRIPTION
There are now three spots in this code base that need a method to collect the line items that pass all applicable rules for an order and can be discounted. Time to extract.