### PR TITLE
Fix admin sub menu entry visibility condition

### DIFF
--- a/app/views/solidus_friendly_promotions/admin/shared/_promotion_sub_menu.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/shared/_promotion_sub_menu.html.erb
@@ -5,10 +5,10 @@
   <% if can? :admin, SolidusFriendlyPromotions::PromotionCategory %>
     <%= tab url: solidus_friendly_promotions.admin_promotion_categories_path, label: :promotion_categories %>
   <% end %>
-  <% if can? :admin, Spree::Promotion && Spree::Promotion.any? %>
+  <% if can?(:admin, Spree::Promotion) && Spree::Promotion.any? %>
     <%= tab url: spree.admin_promotions_path, label: :legacy_promotions %>
   <% end %>
-  <% if can? :admin, Spree::PromotionCategory && Spree::PromotionCategory.any? %>
+  <% if can?(:admin, Spree::PromotionCategory) && Spree::PromotionCategory.any? %>
     <%= tab url: spree.admin_promotion_categories_path, label: :legacy_promotion_categories %>
   <% end %>
 </ul>


### PR DESCRIPTION
This condition
```RUBY
can? :admin, Spree::Promotion && Spree::Promotion.any?
```
Interprets as
```RUBY
can? :admin, (Spree::Promotion && Spree::Promotion.any?) # =>
can? :admin, [false/true] # => always true for admin =>  
# shows legacy menu item even when no Spree::Promotion present
```