### PR TITLE
Test ENV loading issue

### DIFF
--- a/app/models/solidus_friendly_promotions/friendly_promotion_adjuster.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_adjuster.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# require_relative 'friendly_promotion_adjuster/choose_discounts'
+# require_relative 'friendly_promotion_adjuster/discount_order'
+# require_relative 'friendly_promotion_adjuster/load_promotions'
+# require_relative 'friendly_promotion_adjuster/persist_discounted_order'
+
+# OR
+
+# Dir[File.join(__dir__, 'friendly_promotion_adjuster', '*.rb')].each { |file| require file }
+
 module SolidusFriendlyPromotions
   class FriendlyPromotionAdjuster
     attr_reader :order, :promotions, :dry_run

--- a/lib/solidus_friendly_promotions/testing_support.rb
+++ b/lib/solidus_friendly_promotions/testing_support.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Dir[::SolidusFriendlyPromotions::Engine.root.join("app", "models", "solidus_friendly_promotions", "friendly_promotion_adjuster", "*.rb")].each { |file| require file }
+
 module SolidusFriendlyPromotions
   module TestingSupport
     def self.factories_path


### PR DESCRIPTION
Test ENV does not eagerly load files by default. This causes issues with some solidus factories. The factory `shipped_order` for example raises a NameError:

> NameError: uninitialized constant SolidusFriendlyPromotions::FriendlyPromotionAdjuster::LoadPromotions

There are three ways I see and have confirmed that resolve the issue that have been presented here (as commments).
- In friendly_promotion_adjuster.rb explicitly require the files
- In friendly_promotion_adjuster.rb use dir to require all listed files. This approach is future proof, but lacks intentionality
- In test_support require files preventing any loading changes for production