### PR TITLE
Add configuration option: `recalculate_complete_orders`

### DIFF
--- a/app/models/solidus_friendly_promotions/friendly_promotion_adjuster.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_adjuster.rb
@@ -13,7 +13,8 @@ module SolidusFriendlyPromotions
     def call
       order.reset_current_discounts
 
-      return order if order.shipped?
+      return order if (!SolidusFriendlyPromotions.config.recalculate_complete_orders && order.complete?) || order.shipped?
+
       discounted_order = DiscountOrder.new(order, promotions, dry_run: dry_run).call
 
       PersistDiscountedOrder.new(discounted_order).call unless dry_run

--- a/lib/solidus_friendly_promotions/configuration.rb
+++ b/lib/solidus_friendly_promotions/configuration.rb
@@ -5,10 +5,12 @@ require "spree/core/environment_extension"
 module SolidusFriendlyPromotions
   class Configuration < Spree::Preferences::Configuration
     attr_accessor :sync_order_promotions
+    attr_accessor :recalculate_complete_orders
     attr_accessor :promotion_calculators
 
     def initialize
       @sync_order_promotions = true
+      @recalculate_complete_orders = true
       @promotion_calculators = NestedClassSet.new
     end
 

--- a/spec/lib/solidus_friendly_promotions/configuration_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/configuration_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe SolidusFriendlyPromotions::Configuration do
       config.sync_order_promotions = true
     end
   end
+
+  describe ".recalculate_complete_orders" do
+    subject { config.recalculate_complete_orders }
+
+    it { is_expected.to be true }
+
+    it "can be set to false" do
+      config.recalculate_complete_orders = false
+      expect(subject).to be false
+      config.recalculate_complete_orders = true
+    end
+  end
 end


### PR DESCRIPTION
This gem allows recalculating complete orders until they are shipped, because Solidus allows changing an order's contents until the order is shipped.

This change adds a configuration option that disables the recalculation of orders after they are completed. Some shops make changes to existing promotions, and expect that this does not change complete, but unshipped orders.