### PR TITLE
Define SolidusFriendlyPromotions.table_name_prefix early

### DIFF
--- a/app/models/solidus_friendly_promotions.rb
+++ b/app/models/solidus_friendly_promotions.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module SolidusFriendlyPromotions
-  def self.table_name_prefix
-    "friendly_"
-  end
-end

--- a/config/initializers/solidus_friendly_promotions.rb
+++ b/config/initializers/solidus_friendly_promotions.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative SolidusFriendlyPromotions::Engine.root.join("app/models/solidus_friendly_promotions.rb")

--- a/lib/solidus_friendly_promotions.rb
+++ b/lib/solidus_friendly_promotions.rb
@@ -7,13 +7,18 @@ require "turbo-rails"
 require "importmap-rails"
 require "stimulus-rails"
 require "ransack-enum"
-require "solidus_friendly_promotions/nested_class_set"
-require "solidus_friendly_promotions/configuration"
-require "solidus_friendly_promotions/version"
-require "solidus_friendly_promotions/engine"
 
 module SolidusFriendlyPromotions
+  def self.table_name_prefix
+    "friendly_"
+  end
+
   # JS Importmap instance
   singleton_class.attr_accessor :importmap
   self.importmap = Importmap::Map.new
 end
+
+require "solidus_friendly_promotions/nested_class_set"
+require "solidus_friendly_promotions/configuration"
+require "solidus_friendly_promotions/version"
+require "solidus_friendly_promotions/engine"


### PR DESCRIPTION
In Rails 7.1.3, the `table_name_prefix` method is redefined if it is not already defined. Since we have multiple module definitions, we need to make sure that the class method is defined before we load `engine.rb`.