### PR TITLE
Revert "Temporarily disable running specs for Solidus main"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - solidusio_extensions/dependencies
       - solidusio_extensions/run-tests-solidus-current
-      # - solidusio_extensions/run-tests-solidus-main
+      - solidusio_extensions/run-tests-solidus-main
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
@@ -31,7 +31,7 @@ jobs:
       - checkout
       - solidusio_extensions/dependencies
       - solidusio_extensions/run-tests-solidus-current
-      # - solidusio_extensions/run-tests-solidus-main
+      - solidusio_extensions/run-tests-solidus-main
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - solidusio_extensions/dependencies
       - solidusio_extensions/run-tests-solidus-current
-      # - solidusio_extensions/run-tests-solidus-main
+      - solidusio_extensions/run-tests-solidus-main
 workflows:
   Run specs on supported Solidus versions:
     jobs:


### PR DESCRIPTION
This reverts commit cdf3f41529e87e45d6aae8a82a5a536cc01b87e3.

Solidus main has been fixed.