### PR TITLE
Add missing association between promo codes and order promotions

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_code.rb
+++ b/app/models/solidus_friendly_promotions/promotion_code.rb
@@ -4,6 +4,8 @@ module SolidusFriendlyPromotions
   class PromotionCode < Spree::Base
     belongs_to :promotion, inverse_of: :codes
     belongs_to :promotion_code_batch, inverse_of: :promotion_codes, optional: true
+
+    has_many :order_promotions, class_name: "SolidusFriendlyPromotions::OrderPromotion", dependent: :destroy
     has_many :adjustments, class_name: "Spree::Adjustment"
 
     before_validation :normalize_code


### PR DESCRIPTION
This fixes the foreign key constraint error when deleting a promotion code that has been applied to an order.

This will, of course, change the applicability of the promotion in question for that particular order. If the order is shipped, no worries though: The adjustments will stay as our service object will not try to recalculate. If the order is not shipped, the promotion will stop being applied. However, if you as a user deleted the promotion or the promotion code, that's probably what you want.

Fixes #94