### PR TITLE
Improve soft-deletion faculty

### DIFF
--- a/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
+++ b/app/controllers/solidus_friendly_promotions/admin/promotion_actions_controller.rb
@@ -53,7 +53,7 @@ module SolidusFriendlyPromotions
 
       def destroy
         @promotion_action = @promotion.actions.find(params[:id])
-        if @promotion_action.discard
+        if @promotion_action.destroy
           flash[:success] =
             t("spree.successfully_removed", resource: SolidusFriendlyPromotions::PromotionAction.model_name.human)
         end

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -8,7 +8,7 @@ module SolidusFriendlyPromotions
       foreign_key: :promotion_category_id, optional: true
     belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true
     has_many :rules, class_name: "SolidusFriendlyPromotions::PromotionRule", dependent: :destroy
-    has_many :actions, class_name: "SolidusFriendlyPromotions::PromotionAction", dependent: :nullify
+    has_many :actions, class_name: "SolidusFriendlyPromotions::PromotionAction", dependent: :destroy
     has_many :codes, class_name: "SolidusFriendlyPromotions::PromotionCode", dependent: :destroy
     has_many :code_batches, class_name: "SolidusFriendlyPromotions::PromotionCodeBatch", dependent: :destroy
     has_many :order_promotions, class_name: "SolidusFriendlyPromotions::OrderPromotion", dependent: :destroy

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -51,7 +51,7 @@ module SolidusFriendlyPromotions
 
     self.allowed_ransackable_associations = ["codes"]
     self.allowed_ransackable_attributes = %w[name customer_label path promotion_category_id lane updated_at]
-    self.allowed_ransackable_scopes = %i[active]
+    self.allowed_ransackable_scopes = %i[active with_discarded]
 
     # All orders that have been discounted using this promotion
     def discounted_orders

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -2,6 +2,8 @@
 
 module SolidusFriendlyPromotions
   class Promotion < Spree::Base
+    include Spree::SoftDeletable
+
     belongs_to :category, class_name: "SolidusFriendlyPromotions::PromotionCategory",
       foreign_key: :promotion_category_id, optional: true
     belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -9,7 +9,6 @@ module SolidusFriendlyPromotions
   # by an event and determined to be eligible.
   class PromotionAction < Spree::Base
     include Spree::Preferences::Persistable
-    include Spree::SoftDeletable
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource
     before_destroy :remove_adjustments_from_incomplete_orders

--- a/app/views/solidus_friendly_promotions/admin/promotions/_table.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/_table.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody>
     <% promotions.each do |promotion| %>
-      <tr id="<%= spree_dom_id promotion %>">
+      <tr class="<%= 'deleted' if promotion.discarded? %>" id="<%= spree_dom_id promotion %>">
         <td><%= promotion.name %></td>
         <td>
           <%= (promotion.codes.size == 1) ? promotion.codes.pluck(:value).first : t('solidus_friendly_promotions.number_of_codes', count: promotion.codes.size) %>
@@ -43,10 +43,10 @@
           <%= l(promotion.updated_at, format: :short) %>
         </td>
         <td class="actions">
-          <% if can?(:edit, promotion) %>
+          <% if can?(:edit, promotion) && !promotion.discarded? %>
             <%= link_to_edit promotion, no_text: true %>
           <% end %>
-          <% if can?(:destroy, promotion) %>
+          <% if can?(:destroy, promotion) && !promotion.discarded? %>
             <%= link_to_delete promotion, no_text: true %>
           <% end %>
         </td>

--- a/app/views/solidus_friendly_promotions/admin/promotions/_table_filter.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/_table_filter.html.erb
@@ -44,6 +44,15 @@
         </div>
 
         <div class="col-2">
+          <div class="field checkbox">
+            <label>
+              <%= f.check_box :with_discarded, { checked: params[:q][:with_discarded] == 'true', class: 'js-with-discarded-input' }, 'true', 'false' %>
+              <%= t('spree.show_deleted') %>
+            </label>
+          </div>
+        </div>
+
+        <div class="col-2">
           <div class="field">
             <%= label_tag :q_promotion_category_id_eq, SolidusFriendlyPromotions::PromotionCategory.model_name.human %><br>
             <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: t(:all, scope: :spree) }, { class: 'custom-select fullwidth' }) %>

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -65,6 +65,7 @@ unbundled bundle exec rake db:drop db:create
 
 unbundled bin/rails generate solidus:install \
   --auto-accept \
+  --admin_preview=false \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,10 @@ en:
 
     errors:
       models:
+        solidus_friendly_promotions/promotion_action:
+          attributes:
+            base:
+              cannot_destroy_if_order_completed: Action has been applied to complete orders. It cannot be destroyed.
         solidus_friendly_promotions/promotion_code:
           attributes:
             base:

--- a/db/migrate/20240124104855_add_deleted_at_to_promotions.rb
+++ b/db/migrate/20240124104855_add_deleted_at_to_promotions.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToPromotions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :friendly_promotions, :deleted_at, :datetime
+    add_index :friendly_promotions, :deleted_at
+  end
+end

--- a/db/migrate/20240125102050_drop_deleted_at_from_promotion_actions.rb
+++ b/db/migrate/20240125102050_drop_deleted_at_from_promotion_actions.rb
@@ -1,0 +1,5 @@
+class DropDeletedAtFromPromotionActions < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :friendly_promotion_actions, :deleted_at, :datetime, null: true
+  end
+end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions_spec.rb
@@ -43,6 +43,25 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::LoadPromoti
         expect(subject).to eq([active_promotion])
       end
     end
+
+    context "discarded promotions" do
+      let!(:discarded_promotion) { create(:friendly_promotion, :with_adjustable_action, deleted_at: 1.hour.ago, apply_automatically: true) }
+
+      it "does not check discarded promotions" do
+        expect(subject).not_to include(discarded_promotion)
+      end
+
+      context "a discarded promo is connected to the order" do
+        before do
+          order.friendly_promotions << discarded_promotion
+        end
+
+        it "does not check connected discarded promotions" do
+          expect(subject).not_to include(discarded_promotion)
+          expect(subject).to eq([active_promotion])
+        end
+      end
+    end
   end
 
   context "promotions in the past" do


### PR DESCRIPTION
Prior to this PR, soft deletion was implemented for the `SolidusFriendlyPromotion::PromotionAction`. However, there was no UI making soft-deleted records visible, and it appears this was only done so that `Spree::Adjustment` records never lose their source. 

This PR moves the soft-deletion faculty to the `SolidusFriendlyPromotion::Promotion` model, adds a little bit of UI to make them visible if necessary, and tells the `Spree::PromotionAction` model how to deal with adjustments: If there's adjustments where the order is complete, refuse to be deleted, if there's adjustments where the order is incomplete, delete those adjustments. 

Fixes #30 