### PR TITLE
Fix Promotion Rule Unique per promotion validation

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -45,7 +45,7 @@ module SolidusFriendlyPromotions
     def unique_per_promotion
       return unless self.class.exists?(promotion_id: promotion_id, type: self.class.name)
 
-      errors[:base] << "Promotion already contains this rule type"
+      errors.add(:promotion, :already_contains_rule_type)
     end
 
     def eligibility_error_message(key, options = {})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,10 @@ en:
           attributes:
             base:
               cannot_destroy_if_order_completed: Action has been applied to complete orders. It cannot be destroyed.
+        solidus_friendly_promotions/promotion_rule:
+          attributes:
+            promotion:
+              already_contains_rule_type: already contains this rule type
         solidus_friendly_promotions/promotion_code:
           attributes:
             base:

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
@@ -115,8 +115,9 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       end
 
       context "with a second line item level rule" do
+        let(:hats) { create(:taxon, name: "Hats", products: [hat]) }
         let(:hat) { create(:product) }
-        let(:hat_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [hat]) }
+        let(:hat_product_rule) { SolidusFriendlyPromotions::Rules::LineItemTaxon.new(taxons: [hats]) }
         let(:rules) { [shirt_product_rule, hat_product_rule] }
 
         it "can tell us about success" do
@@ -127,7 +128,7 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
         it "has errors for this promo" do
           subject
           expect(promotion.eligibility_results.error_messages).to eq([
-            "You need to add an applicable product before applying this coupon code."
+            "This coupon code could not be applied to the cart at this time."
           ])
         end
       end

--- a/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
@@ -28,13 +28,16 @@ RSpec.describe SolidusFriendlyPromotions::PromotionRule do
   end
 
   it "validates unique rules for a promotion" do
-    promotion_one = test_rule_class.new
-    promotion_one.promotion_id = 1
-    promotion_one.save
+    # Because of Rails' STI, we can't use the anonymous class here
+    promotion = create(:friendly_promotion)
+    rule_one = SolidusFriendlyPromotions::Rules::FirstOrder.new
+    rule_one.promotion_id = promotion.id
+    rule_one.save!
 
-    promotion_two = test_rule_class.new
-    promotion_two.promotion_id = 1
-    expect(promotion_two).not_to be_valid
+    rule_two = SolidusFriendlyPromotions::Rules::FirstOrder.new
+    rule_two.promotion_id = promotion.id
+    expect(rule_two).not_to be_valid
+    expect(rule_two.errors.full_messages).to include("Promotion already contains this rule type")
   end
 
   it "generates its own partial path" do


### PR DESCRIPTION
This used outdated syntax that did not actually work, and the spec indicated invalidity because of the promotion with ID = 1 not existing.

Now we create a real promotion to test with, and we add the error in the correct way. As a bonus, we use I18n for the error message.