### PR TITLE
Fix ShippingRateDiscount#promotion_action

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -17,6 +17,7 @@ module SolidusFriendlyPromotions
     belongs_to :promotion, inverse_of: :actions
     belongs_to :original_promotion_action, class_name: "Spree::PromotionAction", optional: true
     has_many :adjustments, class_name: "Spree::Adjustment", as: :source
+    has_many :shipping_rate_discounts, class_name: "SolidusFriendlyPromotions::ShippingRateDiscount", inverse_of: :promotion_action
 
     scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }
 

--- a/app/models/solidus_friendly_promotions/shipping_rate_discount.rb
+++ b/app/models/solidus_friendly_promotions/shipping_rate_discount.rb
@@ -3,7 +3,7 @@
 module SolidusFriendlyPromotions
   class ShippingRateDiscount < Spree::Base
     belongs_to :shipping_rate, inverse_of: :discounts, class_name: "Spree::ShippingRate"
-    belongs_to :promotion_action, -> { with_discarded }, inverse_of: false
+    belongs_to :promotion_action, inverse_of: :shipping_rate_discounts
 
     extend Spree::DisplayMoney
     money_methods :amount

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 RSpec.describe SolidusFriendlyPromotions::PromotionAction do
   it { is_expected.to belong_to(:promotion) }
   it { is_expected.to have_one(:calculator) }
+  it { is_expected.to have_many(:shipping_rate_discounts) }
 
   it { is_expected.to respond_to :discount }
   it { is_expected.to respond_to :can_discount? }

--- a/spec/models/solidus_friendly_promotions/shipping_rate_discount_spec.rb
+++ b/spec/models/solidus_friendly_promotions/shipping_rate_discount_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 RSpec.describe SolidusFriendlyPromotions::ShippingRateDiscount do
   subject(:shipping_rate_discount) { build(:friendly_shipping_rate_discount) }
 
+  it { is_expected.to belong_to(:shipping_rate) }
+
   it { is_expected.to respond_to(:shipping_rate) }
   it { is_expected.to respond_to(:promotion_action) }
   it { is_expected.to respond_to(:amount) }


### PR DESCRIPTION
Promotion actions are not soft-deletable anymore.

Fixes #105 