### PR TITLE
Restrict SQLite to "~> 1.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ when "mysql"
 when "postgresql"
   gem "pg"
 else
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3"
 end
 
 # While we still support Ruby < 3 we need to workaround a limitation in


### PR DESCRIPTION
SQLite 2.0 has recently been released, but the Rails/Solidus ecosystem isn't quite there yet.