### PR TITLE
Fix selenium path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     executor:
       name: solidusio_extensions/sqlite-memory
-      ruby_version: '3.0'
+      ruby_version: '3.1'
     steps:
       - checkout
       - solidusio_extensions/test-branch:
@@ -15,7 +15,7 @@ jobs:
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: '3.1'
+      ruby_version: '3.2'
     steps:
       - browser-tools/install-chrome
       - checkout
@@ -25,7 +25,7 @@ jobs:
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: '3.2'
+      ruby_version: '3.3'
     steps:
       - browser-tools/install-chrome
       - checkout
@@ -35,7 +35,7 @@ jobs:
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '3.0'
+      ruby_version: '3.1'
     steps:
       - browser-tools/install-chrome
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -27,11 +27,6 @@ else
   gem "sqlite3", "~> 1.3"
 end
 
-# While we still support Ruby < 3 we need to workaround a limitation in
-# the 'async' gem that relies on the latest ruby, since RubyGems doesn't
-# resolve gems based on the required ruby version.
-gem "async", "< 3" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3")
-
 gemspec
 
 # Use a local Gemfile to include development dependencies that might not be

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,10 +29,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
-  if Spree.solidus_gem_version < Gem::Version.new("2.11")
-    config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :system
-  end
-
   config.include SolidusFriendlyPromotions::Engine.routes.url_helpers, type: :request
 end
 


### PR DESCRIPTION
The production code would still run with Ruby 3.0, but the test suite will use a version of Rails that doesn't play well with the current `selenium-webdrivers` gem. Moving the Ruby versions up by a minor version fixes the test suite.