### PR TITLE
Promotion advertiser

### DIFF
--- a/app/models/solidus_friendly_promotions/promotion_advertiser.rb
+++ b/app/models/solidus_friendly_promotions/promotion_advertiser.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module SolidusFriendlyPromotions
+  class PromotionAdvertiser
+    def self.for_product(product)
+      promotion_ids = ProductsPromotionRule.joins(:promotion_rule).where(product: product).select(:promotion_id).distinct
+      SolidusFriendlyPromotions::Promotion.advertised.where(id: promotion_ids).reject(&:inactive?)
+    end
+  end
+end

--- a/lib/solidus_friendly_promotions/configuration.rb
+++ b/lib/solidus_friendly_promotions/configuration.rb
@@ -29,6 +29,14 @@ module SolidusFriendlyPromotions
     class_name_attribute :promotion_code_batch_mailer_class,
       default: "SolidusFriendlyPromotions::PromotionCodeBatchMailer"
 
+    # Allows providing a different promotion advertiser.
+    # @!attribute [rw] advertiser_class
+    # @see Spree::PromotionAdvertiser
+    # @return [Class] an object that conforms to the API of
+    #   the standard promotion advertiser class
+    #   Spree::PromotionAdvertiser.
+    class_name_attribute :advertiser_class, default: "SolidusFriendlyPromotions::PromotionAdvertiser"
+
     # @!attribute [rw] promotions_per_page
     #   @return [Integer] Promotions to show per-page in the admin (default: +25+)
     preference :promotions_per_page, :integer, default: 25

--- a/spec/lib/solidus_friendly_promotions/configuration_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/configuration_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe SolidusFriendlyPromotions::Configuration do
     end
   end
 
+  describe ".advertiser_class" do
+    it "is the standard advertiser" do
+      expect(subject.advertiser_class).to eq(SolidusFriendlyPromotions::PromotionAdvertiser)
+    end
+  end
+
   describe ".promotion_calculators" do
     subject { config.promotion_calculators }
 

--- a/spec/models/solidus_friendly_promotions/promotion_advertiser_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_advertiser_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusFriendlyPromotions::PromotionAdvertiser, type: :model do
+  describe ".for_product" do
+    subject { described_class.for_product(product) }
+
+    let(:product) { create(:product) }
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, advertise: true, starts_at: 1.day.ago) }
+    let!(:rule) do
+      SolidusFriendlyPromotions::Rules::LineItemProduct.create(
+        promotion: promotion,
+        products: [product]
+      )
+    end
+
+    it "lists the promotion as a possible promotion" do
+      expect(subject).to include(promotion)
+    end
+  end
+end


### PR DESCRIPTION
In https://github.com/solidusio/solidus/pull/5739, Solidus introduces a promotion advertiser class. 

This implements that configuration endpoint for this gem.