### PR TITLE
Rules per action

### DIFF
--- a/app/controllers/solidus_friendly_promotions/admin/promotion_rules_controller.rb
+++ b/app/controllers/solidus_friendly_promotions/admin/promotion_rules_controller.rb
@@ -5,22 +5,19 @@ module SolidusFriendlyPromotions
     class PromotionRulesController < Spree::Admin::BaseController
       helper "solidus_friendly_promotions/admin/promotion_rules"
 
-      before_action :validate_level, only: [:new, :create]
-      before_action :load_promotion, only: [:create, :destroy, :update, :new]
-      before_action :validate_promotion_rule_type, only: [:create]
+      before_action :load_promotion_action, only: [:create, :destroy, :update, :new]
+      rescue_from ActiveRecord::SubclassNotFound, with: :invalid_rule_error
 
       def new
         if params.dig(:promotion_rule, :type)
-          validate_promotion_rule_type
-          @promotion_rule = @promotion.rules.build(type: @promotion_rule_type)
+          promotion_rule_type = params[:promotion_rule][:type]
+          @promotion_rule = @promotion_action.conditions.build(type: promotion_rule_type)
         end
         render layout: false
       end
 
       def create
-        @promotion_rule = @promotion.rules.build(
-          promotion_rule_params.merge(type: @promotion_rule_type.to_s)
-        )
+        @promotion_rule = @promotion_action.conditions.build(promotion_rule_params)
         if @promotion_rule.save
           flash[:success] =
             t("spree.successfully_created", resource: SolidusFriendlyPromotions::PromotionRule.model_name.human)
@@ -29,7 +26,7 @@ module SolidusFriendlyPromotions
       end
 
       def update
-        @promotion_rule = @promotion.rules.find(params[:id])
+        @promotion_rule = @promotion_action.conditions.find(params[:id])
         @promotion_rule.assign_attributes(promotion_rule_params)
         if @promotion_rule.save
           flash[:success] =
@@ -39,7 +36,7 @@ module SolidusFriendlyPromotions
       end
 
       def destroy
-        @promotion_rule = @promotion.rules.find(params[:id])
+        @promotion_rule = @promotion_action.conditions.find(params[:id])
         if @promotion_rule.destroy
           flash[:success] =
             t("spree.successfully_removed", resource: SolidusFriendlyPromotions::PromotionRule.model_name.human)
@@ -49,56 +46,26 @@ module SolidusFriendlyPromotions
 
       private
 
+      def invalid_rule_error
+        flash[:error] = t("solidus_friendly_promotions.invalid_rule")
+        redirect_to location_after_save
+      end
+
       def location_after_save
         solidus_friendly_promotions.edit_admin_promotion_path(@promotion)
       end
 
-      def load_promotion
+      def load_promotion_action
         @promotion = SolidusFriendlyPromotions::Promotion.find(params[:promotion_id])
+        @promotion_action = @promotion.actions.find(params[:promotion_action_id])
       end
 
       def model_class
         SolidusFriendlyPromotions::PromotionRule
       end
 
-      def validate_promotion_rule_type
-        requested_type = params[:promotion_rule].delete(:type)
-        promotion_rule_types = SolidusFriendlyPromotions.config.send(:"#{@level}_rules")
-        @promotion_rule_type = promotion_rule_types.detect do |klass|
-          klass.name == requested_type
-        end
-        return if @promotion_rule_type
-
-        flash[:error] = t("solidus_friendly_promotions.invalid_promotion_rule")
-        respond_to do |format|
-          format.html { redirect_to solidus_friendly_promotions.edit_admin_promotion_path(@promotion) }
-          format.js { render layout: false }
-        end
-      end
-
-      def validate_level
-        requested_level = params[:level].to_s
-        if requested_level.in?(["order", "line_item", "shipment"])
-          @level = requested_level
-        else
-          @level = "order"
-          flash.now[:error] = t(:invalid_promotion_rule_level, scope: :solidus_friendly_promotions)
-        end
-      end
-
       def promotion_rule_params
         params[:promotion_rule].try(:permit!) || {}
-      end
-
-      def promotion_rule_types
-        case params[:level]
-        when "order"
-          SolidusFriendlyPromotions.config.order_rules
-        when "line_item"
-          SolidusFriendlyPromotions.config.line_item_rules
-        when "shipment"
-          SolidusFriendlyPromotions.config.shipment_rules
-        end
       end
     end
   end

--- a/app/helpers/solidus_friendly_promotions/admin/promotion_rules_helper.rb
+++ b/app/helpers/solidus_friendly_promotions/admin/promotion_rules_helper.rb
@@ -3,11 +3,9 @@
 module SolidusFriendlyPromotions
   module Admin
     module PromotionRulesHelper
-      def options_for_promotion_rule_types(promotion_rule, level)
-        existing = promotion_rule.promotion.rules.select(&:persisted?).map { |rule| rule.class.name }
-        rules = SolidusFriendlyPromotions.config.send(:"#{level}_rules").reject { |rule| existing.include? rule.name }
-        options = rules.map { |rule| [rule.model_name.human, rule.name] }
-        options_for_select(options, promotion_rule.type.to_s)
+      def options_for_promotion_rule_types(promotion_action, promotion_rule)
+        options = promotion_action.available_conditions.map { |condition| [condition.model_name.human, condition.name] }
+        options_for_select(options, promotion_rule&.type.to_s)
       end
 
       def promotion_rules_by_level(promotion, level)

--- a/app/javascript/solidus_friendly_promotions.js
+++ b/app/javascript/solidus_friendly_promotions.js
@@ -12,4 +12,3 @@ const initPickers = ({ _target }) => {
   $(".variant_autocomplete").variantAutocomplete();
 };
 document.addEventListener("turbo:frame-load", initPickers);
-document.addEventListener("DOMContentLoaded", initPickers);

--- a/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_line_item.rb
@@ -10,6 +10,10 @@ module SolidusFriendlyPromotions
       def level
         :line_item
       end
+
+      def possible_conditions
+        super + SolidusFriendlyPromotions.config.line_item_rules
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/actions/adjust_line_item_quantity_groups.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_line_item_quantity_groups.rb
@@ -58,7 +58,7 @@ module SolidusFriendlyPromotions
         adjustment_amount = adjustment_amount.abs
 
         order = line_item.order
-        line_items = promotion.applicable_line_items(order)
+        line_items = applicable_line_items(order)
 
         item_units = line_items.sort_by do |line_item|
           [-line_item.quantity, line_item.id]

--- a/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
+++ b/app/models/solidus_friendly_promotions/actions/adjust_shipment.rb
@@ -10,6 +10,12 @@ module SolidusFriendlyPromotions
       def level
         :shipment
       end
+
+      private
+
+      def possible_conditions
+        super + SolidusFriendlyPromotions.config.shipment_rules
+      end
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/actions/create_discounted_item.rb
+++ b/app/models/solidus_friendly_promotions/actions/create_discounted_item.rb
@@ -30,11 +30,10 @@ module SolidusFriendlyPromotions
       end
 
       def determine_item_quantity(order)
-        applicable_line_items = promotion.applicable_line_items(order)
         # Integer division will floor automatically, which is what we want here:
         # 1 Item, 2 needed: 1 * 1 / 2 => 0
         # 5 items, 2 preferred, 2 needed: 5 / 2 * 2 => 4
-        applicable_line_items.sum(&:quantity) / preferred_necessary_quantity * preferred_quantity
+        applicable_line_items(order).sum(&:quantity) / preferred_necessary_quantity * preferred_quantity
       end
 
       def set_quantity(line_item, quantity)

--- a/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
+++ b/app/models/solidus_friendly_promotions/calculators/distributed_amount.rb
@@ -18,7 +18,7 @@ module SolidusFriendlyPromotions
         return 0 unless line_item
         return 0 unless preferred_currency.casecmp(line_item.currency).zero?
 
-        distributable_line_items = calculable.promotion.applicable_line_items(line_item.order)
+        distributable_line_items = calculable.applicable_line_items(line_item.order)
         return 0 unless line_item.in?(distributable_line_items)
 
         DistributedAmountsHandler.new(

--- a/app/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
+++ b/app/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
@@ -29,7 +29,7 @@ module SolidusFriendlyPromotions
       private
 
       def eligible_line_items_quantity_total(order)
-        calculable.promotion.applicable_line_items(order).sum(&:quantity)
+        calculable.applicable_line_items(order).sum(&:quantity)
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/eligibility_result.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_result.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusFriendlyPromotions
-  EligibilityResult = Struct.new(:item, :rule, :success, :code, :message, keyword_init: true)
+  EligibilityResult = Struct.new(:item, :condition, :success, :code, :message, keyword_init: true)
 end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -22,7 +22,7 @@ module SolidusFriendlyPromotions
     def success?
       return true if results.empty?
       promotion.actions.any? do |action|
-        action.relevant_rules.all? do |rule|
+        action.conditions.all? do |rule|
           results_for_rule = results.select { |result| result.rule == rule }
           results_for_rule.any?(&:success)
         end

--- a/app/models/solidus_friendly_promotions/eligibility_results.rb
+++ b/app/models/solidus_friendly_promotions/eligibility_results.rb
@@ -9,10 +9,10 @@ module SolidusFriendlyPromotions
       @results = []
     end
 
-    def add(item:, rule:, success:, code:, message:)
+    def add(item:, condition:, success:, code:, message:)
       results << EligibilityResult.new(
         item: item,
-        rule: rule,
+        condition: condition,
         success: success,
         code: code,
         message: message
@@ -22,16 +22,16 @@ module SolidusFriendlyPromotions
     def success?
       return true if results.empty?
       promotion.actions.any? do |action|
-        action.conditions.all? do |rule|
-          results_for_rule = results.select { |result| result.rule == rule }
-          results_for_rule.any?(&:success)
+        action.conditions.all? do |condition|
+          results_for_condition = results.select { |result| result.condition == condition }
+          results_for_condition.any?(&:success)
         end
       end
     end
 
     def error_messages
       return [] if results.empty?
-      results.group_by(&:rule).map do |rule, results|
+      results.group_by(&:condition).map do |condition, results|
         next if results.any?(&:success)
         results.detect { |r| !r.success }&.message
       end.compact

--- a/app/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions.rb
@@ -13,9 +13,9 @@ module SolidusFriendlyPromotions
         promos << dry_run_promotion if dry_run_promotion
         promos.flat_map(&:actions).group_by(&:preload_relations).each do |preload_relations, actions|
           preload(records: actions, associations: preload_relations)
-        end
-        promos.flat_map(&:rules).group_by(&:preload_relations).each do |preload_relations, rules|
-          preload(records: rules, associations: preload_relations)
+          actions.flat_map(&:conditions).group_by(&:preload_relations).each do |preload_relations, conditions|
+            preload(records: conditions, associations: preload_relations)
+          end
         end
         promos.reject { |promotion| promotion.usage_limit_exceeded?(excluded_orders: [order]) }
       end
@@ -44,10 +44,9 @@ module SolidusFriendlyPromotions
       end
 
       def promotion_includes
-        [
-          :rules,
-          :actions
-        ]
+        {
+          actions: :conditions
+        }
       end
     end
   end

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -63,12 +63,6 @@ module SolidusFriendlyPromotions
       raise NotImplementedError
     end
 
-    def relevant_rules
-      promotion.rules.select do |rule|
-        rule.level.in?([:order, level].uniq)
-      end
-    end
-
     def available_calculators
       SolidusFriendlyPromotions.config.promotion_calculators[self.class] || (raise NotImplementedError)
     end

--- a/app/models/solidus_friendly_promotions/promotion_action.rb
+++ b/app/models/solidus_friendly_promotions/promotion_action.rb
@@ -18,6 +18,7 @@ module SolidusFriendlyPromotions
     belongs_to :original_promotion_action, class_name: "Spree::PromotionAction", optional: true
     has_many :adjustments, class_name: "Spree::Adjustment", as: :source
     has_many :shipping_rate_discounts, class_name: "SolidusFriendlyPromotions::ShippingRateDiscount", inverse_of: :promotion_action
+    has_many :conditions, class_name: "SolidusFriendlyPromotions::PromotionRule", foreign_key: :action_id, dependent: :destroy
 
     scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }
 

--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -6,7 +6,8 @@ module SolidusFriendlyPromotions
   class PromotionRule < Spree::Base
     include Spree::Preferences::Persistable
 
-    belongs_to :promotion
+    belongs_to :promotion, optional: true
+    belongs_to :action, class_name: "SolidusFriendlyPromotions::PromotionAction", optional: true
 
     scope :of_type, ->(type) { where(type: type) }
 

--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -6,8 +6,8 @@ module SolidusFriendlyPromotions
   class PromotionRule < Spree::Base
     include Spree::Preferences::Persistable
 
-    belongs_to :promotion, optional: true
-    belongs_to :action, class_name: "SolidusFriendlyPromotions::PromotionAction", optional: true
+    belongs_to :action, class_name: "SolidusFriendlyPromotions::PromotionAction", inverse_of: :conditions, optional: true
+    has_one :promotion, through: :action
 
     scope :of_type, ->(type) { where(type: type) }
 
@@ -44,7 +44,7 @@ module SolidusFriendlyPromotions
     private
 
     def unique_per_promotion
-      return unless self.class.exists?(promotion_id: promotion_id, type: self.class.name)
+      return unless self.class.exists?(action_id: action_id, type: self.class.name)
 
       errors.add(:promotion, :already_contains_rule_type)
     end

--- a/app/models/solidus_friendly_promotions/promotion_rule.rb
+++ b/app/models/solidus_friendly_promotions/promotion_rule.rb
@@ -11,7 +11,7 @@ module SolidusFriendlyPromotions
 
     scope :of_type, ->(type) { where(type: type) }
 
-    validate :unique_per_promotion, on: :create
+    validate :unique_per_action, on: :create
 
     def preload_relations
       []
@@ -43,10 +43,10 @@ module SolidusFriendlyPromotions
 
     private
 
-    def unique_per_promotion
+    def unique_per_action
       return unless self.class.exists?(action_id: action_id, type: self.class.name)
 
-      errors.add(:promotion, :already_contains_rule_type)
+      errors.add(:action, :already_contains_rule_type)
     end
 
     def eligibility_error_message(key, options = {})

--- a/app/models/solidus_friendly_promotions/rules/minimum_quantity.rb
+++ b/app/models/solidus_friendly_promotions/rules/minimum_quantity.rb
@@ -27,7 +27,7 @@ module SolidusFriendlyPromotions
       # @param order [Spree::Order] the order we want to check eligibility on
       # @return [Boolean] true if promotion is eligible, false otherwise
       def eligible?(order)
-        if promotion.applicable_line_items(order).sum(&:quantity) < preferred_minimum_quantity
+        if action.applicable_line_items(order).sum(&:quantity) < preferred_minimum_quantity
           eligibility_errors.add(
             :base,
             eligibility_error_message(:quantity_less_than_minimum, count: preferred_minimum_quantity),

--- a/app/views/solidus_friendly_promotions/admin/promotion_actions/_promotion_action.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_actions/_promotion_action.html.erb
@@ -1,29 +1,45 @@
-<%= turbo_frame_tag @promotion, dom_id(promotion_action) do %>
-  <div class="promotion_action promotion-block">
-    <h6 class='promotion-title'> <%= promotion_action.model_name.human %></h6>
+<div class="row">
+  <div class="col-6">
+    <%= turbo_frame_tag @promotion, dom_id(promotion_action) do %>
 
-    <% if can?(:destroy, promotion_action) %>
-      <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, promotion_action), method: :delete, class: 'delete' %>
-    <% end %>
+    <div class="promotion_action promotion-block">
+      <h6 class='promotion-title'> <%= promotion_action.model_name.human %></h6>
+
+      <% if can?(:destroy, promotion_action) %>
+        <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, promotion_action), method: :delete, class: 'delete' %>
+      <% end %>
 
 
-    <%= render "solidus_friendly_promotions/admin/promotion_actions/calculator_select",
-      path: solidus_friendly_promotions.edit_admin_promotion_promotion_action_path(@promotion, promotion_action),
-      promotion_action: promotion_action %>
+      <%= render "solidus_friendly_promotions/admin/promotion_actions/calculator_select",
+        path: solidus_friendly_promotions.edit_admin_promotion_promotion_action_path(@promotion, promotion_action),
+        promotion_action: promotion_action %>
 
-    <%=
-      form_with(
-      model: promotion_action,
-      scope: :promotion_action,
-      url: solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, promotion_action),
-      data: { turbo: false }
-    ) do |form| %>
-      <%= render 'solidus_friendly_promotions/admin/promotion_actions/form', form: form %>
-      <div class="row">
-        <div class="col-12">
-          <%= button_tag t(:update, scope: [:solidus_friendly_promotions, :crud]), class: "btn btn-secondary float-right" %>
+      <%=
+        form_with(
+        model: promotion_action,
+        scope: :promotion_action,
+        url: solidus_friendly_promotions.admin_promotion_promotion_action_path(@promotion, promotion_action),
+        data: { turbo: false }
+      ) do |form| %>
+        <%= render 'solidus_friendly_promotions/admin/promotion_actions/form', form: form %>
+        <div class="row">
+          <div class="col-12">
+            <%= button_tag t(:update, scope: [:solidus_friendly_promotions, :crud]), class: "btn btn-secondary float-right" %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-<% end %>
+  <% end %>
+
+  <div class="col-6">
+    <fieldset>
+      <legend align="center"><%= t("promotion_conditions", scope: :solidus_friendly_promotions) %></legend>
+        <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_action.conditions %>
+
+        <%= turbo_frame_tag promotion_action, "new_promotion_rule" do %>
+          <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_action_promotion_rule_path(@promotion, promotion_action), class: 'btn btn-secondary' %>
+        <% end %>
+    </fieldset>
+  </div>
+</div>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/_promotion_rule.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/_promotion_rule.html.erb
@@ -1,17 +1,17 @@
 
 <div class="promotion_rule promotion-block" id="<%= dom_id promotion_rule %>">
-  <%= form_with model: promotion_rule, scope: :promotion_rule, url: solidus_friendly_promotions.admin_promotion_promotion_rule_path(@promotion, promotion_rule), method: :patch do |form| %>
+  <%= form_with model: promotion_rule, scope: :promotion_rule, url: solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rule_path(@promotion, promotion_rule.action, promotion_rule), method: :patch do |form| %>
     <h6 class='promotion-title'><%= promotion_rule.class.model_name.human %></h6>
-    <% if can?(:destroy, promotion_rule) && promotion_rule.level == level %>
-      <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_rule_path(@promotion, promotion_rule), method: :delete, class: 'delete' %>
+    <% if can?(:destroy, promotion_rule) %>
+      <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rule_path(@promotion, promotion_rule.action, promotion_rule), method: :delete, class: 'delete' %>
     <% end %>
 
     <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
     <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
     <%= render partial: "spree/shared/error_messages", locals: { target: promotion_rule } %>
-    <%= render promotion_rule, promotion_rule: promotion_rule, param_prefix: "promotion_rule", form: form, context: level %>
+    <%= render promotion_rule, promotion_rule: promotion_rule, param_prefix: "promotion_rule", form: form %>
 
-    <% if promotion_rule.updateable? && promotion_rule.level == level %>
+    <% if promotion_rule.updateable? %>
       <div class="row">
         <div class="col-12">
           <%= form.submit(t(:update, scope: [:solidus_friendly_promotions, :crud]), class: "btn btn-secondary float-right") %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/_type_select.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/_type_select.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
     model: @promotion_rule || SolidusFriendlyPromotions::PromotionRule.new(promotion: @promotion),
     scope: :promotion_rule,
-    url: solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion),
+    url: solidus_friendly_promotions.new_admin_promotion_promotion_action_promotion_rule_path(@promotion),
     method: :get
   ) do |form| %>
   <%= hidden_field_tag :level, @level %>
@@ -9,7 +9,7 @@
   <%= admin_hint SolidusFriendlyPromotions::PromotionRule.human_attribute_name(:type), t(:promotions, scope: [:solidus_friendly_promotions, :hints, "spree/calculator"]) %>
   <%=
     form.select :type,
-      options_for_promotion_rule_types(form.object, level),
+      options_for_promotion_rule_types(@promotion_action, @promotion_rule),
       {
         include_blank: t(:choose_promotion_rule, scope: 'solidus_friendly_promotions')
       },

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/new.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/new.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag @promotion, "new_#{@level}_promotion_rule" do %>
+<%= turbo_frame_tag @promotion_action, "new_promotion_rule" do %>
   <div class="promotion_rule promotion-block">
     <h6 class='promotion-title'> <%= t(:add_rule, scope: :solidus_friendly_promotions) %></h6>
     <%= link_to_with_icon 'trash', '', solidus_friendly_promotions.edit_admin_promotion_path(@promotion), class: 'delete' %>
@@ -7,7 +7,7 @@
       <%= content_tag(:div, "", data: { controller: :flash, severity: severity, message: message }) %>
     <% end %>
     <% if @promotion_rule %>
-      <%= form_with model: @promotion_rule, scope: "promotion_rule", url: solidus_friendly_promotions.admin_promotion_promotion_rules_path(@promotion), data: { turbo: false } do |form| %>
+      <%= form_with model: @promotion_rule, scope: "promotion_rule", url: solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rules_path(@promotion, @promotion_action), data: { turbo: false } do |form| %>
         <%= hidden_field_tag :level, @level %>
         <%= hidden_field_tag "promotion_rule[type]", @promotion_rule.class.name %>
         <%= render @promotion_rule, promotion_rule: @promotion_rule, param_prefix: "promotion_rule", form: form %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_product.html.erb
@@ -1,6 +1,3 @@
-<% context = local_assigns[:context] || :order %>
-
-<% if context == :order %>
 <p>
   <%= promotion_rule.class.human_attribute_name(:description) %>
 </p>
@@ -29,16 +26,3 @@
       <% end %>
     </div>
   <% end %>
-<% else %>
-  <p>
-    <% match_policy_translation_key = promotion_rule.preferred_match_policy == "none" ? :exclude : :include %>
-    <%= t(match_policy_translation_key, scope: [:solidus_friendly_promotions, :promotion_rules, :line_item_product, :match_policies]) %>
-  </p>
-  <ul>
-    <% promotion_rule.products.each do |product| %>
-      <li>
-        <%= product.name %>
-      </li>
-    <% end %>
-  </ul>
-<% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotion_rules/rules/_taxon.html.erb
@@ -1,44 +1,28 @@
-<% context = local_assigns[:context] || :order %>
+<p>
+  <%= promotion_rule.class.human_attribute_name(:description) %>
+</p>
+<%= fields_for param_prefix, promotion_rule do |form| %>
+  <div class="field taxons_rule_taxons">
+    <%= form.label :taxon_ids_string, t('solidus_friendly_promotions.taxon_rule.choose_taxons') %>
+    <%= form.hidden_field :taxon_ids_string, value: promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth" %>
+  </div>
 
-<% if context == :order %>
-  <p>
-    <%= promotion_rule.class.human_attribute_name(:description) %>
-  </p>
-  <%= fields_for param_prefix, promotion_rule do |form| %>
-    <div class="field taxons_rule_taxons">
-      <%= form.label :taxon_ids_string, t('solidus_friendly_promotions.taxon_rule.choose_taxons') %>
-      <%= form.hidden_field :taxon_ids_string, value: promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth" %>
-    </div>
+  <div class="field">
+    <%
+      match_policy_options = options_for_select(
+        SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.taxon_rule.match_#{s}"),s] },
+        promotion_rule.preferred_match_policy
+      )
+    %>
+    <% select = form.select :preferred_match_policy, match_policy_options %>
+    <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.taxon_rule.label', select: select).html_safe %>
+    </label>
+  </div>
 
-    <div class="field">
-      <%
-        match_policy_options = options_for_select(
-          SolidusFriendlyPromotions::Rules::Taxon::MATCH_POLICIES.map { |s| [t("solidus_friendly_promotions.taxon_rule.match_#{s}"),s] },
-          promotion_rule.preferred_match_policy
-        )
-      %>
-      <% select = form.select :preferred_match_policy, match_policy_options %>
-      <%= form.label :preferred_match_policy, t('solidus_friendly_promotions.taxon_rule.label', select: select).html_safe %>
-      </label>
-    </div>
-
-    <div class="field">
-      <%= form.label :preferred_line_item_applicable do %>
-        <%= form.check_box :preferred_line_item_applicable %>
-        <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
-      <% end %>
-    </div>
-  <% end %>
-<% else %>
-  <p>
-    <% match_policy_translation_key = promotion_rule.preferred_match_policy == "none" ? :exclude : :include %>
-    <%= t(match_policy_translation_key, scope: [:solidus_friendly_promotions, :promotion_rules, :line_item_taxon, :match_policies]) %>
-  </p>
-  <ul>
-    <% promotion_rule.taxons.each do |taxon| %>
-      <li>
-        <%= taxon.name %>
-      </li>
+  <div class="field">
+    <%= form.label :preferred_line_item_applicable do %>
+      <%= form.check_box :preferred_line_item_applicable %>
+      <%= promotion_rule.class.human_attribute_name(:preferred_line_item_applicable) %>
     <% end %>
-  </ul>
+  </div>
 <% end %>

--- a/app/views/solidus_friendly_promotions/admin/promotions/edit.html.erb
+++ b/app/views/solidus_friendly_promotions/admin/promotions/edit.html.erb
@@ -28,16 +28,12 @@
   <% end %>
 <% end %>
 
-
-<fieldset>
-  <legend align="center"><%= t(:order_rules, scope: :solidus_friendly_promotions) %></legend>
-
-  <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_rules_by_level(@promotion, :order), locals: { level: :order } %>
-
-  <%= turbo_frame_tag @promotion, "new_order_promotion_rule" do %>
-    <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion, level: :order), class: 'btn btn-secondary' %>
-  <% end %>
-</fieldset>
+<% if @promotion.actions.any? %>
+  <fieldset>
+  <legend align="center"><%= t("promotion_actions", scope: :solidus_friendly_promotions) %></legend>
+    <%= render partial: 'solidus_friendly_promotions/admin/promotion_actions/promotion_action', collection: @promotion.actions %>
+  </fieldset>
+<% end %>
 
 <div class="row">
   <div class="col-12">
@@ -45,31 +41,4 @@
       <%= link_to t(:add_action, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_action_path(@promotion), class: 'btn btn-secondary' %>
     <% end %>
   </div>
-</div>
-
-<div class="row">
-  <% [:order, :line_item, :shipment].each do |level| %>
-    <% if promotion_actions_by_level(@promotion, level).any? %>
-      <div class="col-<%= level == :order ? 12 : 6 %>">
-        <fieldset>
-          <legend align="center"><%= t("#{level}_actions", scope: :solidus_friendly_promotions) %></legend>
-
-          <%= render partial: 'solidus_friendly_promotions/admin/promotion_actions/promotion_action', collection: promotion_actions_by_level(@promotion, level), locals: {} %>
-        </fieldset>
-      </div>
-      <% if level != :order %>
-        <div class="col-6">
-          <fieldset>
-            <legend align="center"><%= t("#{level}_rules", scope: :solidus_friendly_promotions) %></legend>
-
-            <%= render partial: 'solidus_friendly_promotions/admin/promotion_rules/promotion_rule', collection: promotion_rules_by_level(@promotion, level), locals: { level: level } %>
-
-            <%= turbo_frame_tag @promotion, "new_#{level}_promotion_rule" do %>
-              <%= link_to t(:add_rule, scope: :solidus_friendly_promotions), solidus_friendly_promotions.new_admin_promotion_promotion_rule_path(@promotion, level: level), class: 'btn btn-secondary' %>
-            <% end %>
-          </fieldset>
-        </div>
-      <% end %>
-    <% end %>
-  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,7 +325,7 @@ en:
               cannot_destroy_if_order_completed: Action has been applied to complete orders. It cannot be destroyed.
         solidus_friendly_promotions/promotion_rule:
           attributes:
-            promotion:
+            action:
               already_contains_rule_type: already contains this rule type
         solidus_friendly_promotions/promotion_code:
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,9 @@ SolidusFriendlyPromotions::Engine.routes.draw do
       resources :promotion_categories, except: [:show]
 
       resources :promotions do
-        resources :promotion_rules
-        resources :promotion_actions
+        resources :promotion_actions do
+          resources :promotion_rules
+        end
         resources :promotion_codes, only: [:index, :new, :create]
         resources :promotion_code_batches, only: [:index, :new, :create] do
           get "/download", to: "promotion_code_batches#download", defaults: {format: "csv"}

--- a/db/migrate/20240409093831_add_action_reference_to_rules.rb
+++ b/db/migrate/20240409093831_add_action_reference_to_rules.rb
@@ -1,0 +1,29 @@
+class AddActionReferenceToRules < ActiveRecord::Migration[7.0]
+  def up
+    remove_foreign_key :friendly_promotion_rules, :friendly_promotions
+    change_column :friendly_promotion_rules, :promotion_id, :integer, null: true
+
+    add_reference :friendly_promotion_rules, :action, index: {name: :rule}, null: true, foreign_key: {to_table: :friendly_promotion_actions}
+
+    SolidusFriendlyPromotions::PromotionRule.reset_column_information
+
+    SolidusFriendlyPromotions::PromotionAction.find_each do |action|
+      SolidusFriendlyPromotions::PromotionRule.where(promotion_id: action.promotion_id).each do |rule|
+        rule.dup.tap do |new_rule|
+          new_rule.preload_relations.each do |relation|
+            new_rule.send(:"#{relation}=", rule.send(relation).dup)
+          end
+          new_rule.action = action
+          new_rule.save!
+        end
+        rule.destroy!
+      end
+    end
+  end
+
+  def down
+    SolidusFriendlyPromotions::PromotionRule.where.not(action_id: nil).delete_all
+    change_column :friendly_promotion_rules, :promotion_id, :integer, null: true
+    add_foreign_key :friendly_promotion_rules, :friendly_promotions, column: :promotion_id
+  end
+end

--- a/db/migrate/20240506142650_remove_promotion_rules_promotion_id.rb
+++ b/db/migrate/20240506142650_remove_promotion_rules_promotion_id.rb
@@ -1,0 +1,5 @@
+class RemovePromotionRulesPromotionId < ActiveRecord::Migration[7.1]
+  def up
+    remove_column :friendly_promotion_rules, :promotion_id
+  end
+end

--- a/lib/solidus_friendly_promotions/promotion_migrator.rb
+++ b/lib/solidus_friendly_promotions/promotion_migrator.rb
@@ -2,7 +2,7 @@
 
 module SolidusFriendlyPromotions
   class PromotionMigrator
-    PROMOTION_IGNORED_ATTRIBUTES = ["id", "type", "promotion_category_id"]
+    PROMOTION_IGNORED_ATTRIBUTES = ["id", "type", "promotion_category_id", "promotion_id"]
 
     attr_reader :promotion_map
 
@@ -24,12 +24,12 @@ module SolidusFriendlyPromotions
             name: promotion.promotion_category.name
           )
         end
-        new_promotion.rules = promotion.rules.flat_map do |old_promotion_rule|
-          generate_new_promotion_rules(old_promotion_rule)
-        end
         new_promotion.actions = promotion.actions.flat_map do |old_promotion_action|
           generate_new_promotion_actions(old_promotion_action)&.tap do |new_promotion_action|
             new_promotion_action.original_promotion_action = old_promotion_action
+            new_promotion_action.conditions = promotion.rules.flat_map do |old_promotion_rule|
+              generate_new_promotion_rules(old_promotion_rule)
+            end
           end
         end.compact
         new_promotion.save!

--- a/lib/solidus_friendly_promotions/testing_support/factories/friendly_promotion_factory.rb
+++ b/lib/solidus_friendly_promotions/testing_support/factories/friendly_promotion_factory.rb
@@ -19,12 +19,13 @@ FactoryBot.define do
         preferred_amount { 10 }
         calculator_class { SolidusFriendlyPromotions::Calculators::FlatRate }
         promotion_action_class { SolidusFriendlyPromotions::Actions::AdjustLineItem }
+        conditions { [] }
       end
 
       after(:create) do |promotion, evaluator|
         calculator = evaluator.calculator_class.new
         calculator.preferred_amount = evaluator.preferred_amount
-        evaluator.promotion_action_class.create!(calculator: calculator, promotion: promotion)
+        evaluator.promotion_action_class.create!(calculator: calculator, promotion: promotion, conditions: evaluator.conditions)
       end
     end
 
@@ -60,32 +61,5 @@ FactoryBot.define do
     end
 
     factory :friendly_promotion_with_order_adjustment, traits: [:with_order_adjustment]
-
-    trait :with_item_total_rule do
-      transient do
-        item_total_threshold_amount { 10 }
-      end
-
-      after(:create) do |promotion, evaluator|
-        rule = SolidusFriendlyPromotions::Rules::ItemTotal.create!(
-          promotion: promotion,
-          preferred_operator: "gte",
-          preferred_amount: evaluator.item_total_threshold_amount
-        )
-        promotion.rules << rule
-        promotion.save!
-      end
-    end
-    factory :friendly_promotion_with_item_total_rule, traits: [:with_item_total_rule]
-    trait :with_first_order_rule do
-      after(:create) do |promotion, _evaluator|
-        rule = SolidusFriendlyPromotions::Rules::FirstOrder.create!(
-          promotion: promotion
-        )
-        promotion.rules << rule
-        promotion.save!
-      end
-    end
-    factory :friendly_promotion_with_first_order_rule, traits: [:with_first_order_rule]
   end
 end

--- a/spec/lib/solidus_friendly_promotions/testing_support/factories_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/testing_support/factories_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe "Friendly Factories" do
     [
       :friendly_promotion,
       :friendly_promotion_with_action_adjustment,
-      :friendly_promotion_with_first_order_rule,
       :friendly_promotion_with_item_adjustment,
-      :friendly_promotion_with_item_total_rule,
       :friendly_promotion_with_order_adjustment,
       :friendly_shipping_rate_discount
     ].each do |factory|

--- a/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_line_item_spec.rb
@@ -22,20 +22,4 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustLineItem do
 
     it { is_expected.to eq(:line_item) }
   end
-
-  describe "#relevant_rules" do
-    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
-    let(:action) { described_class.new(calculator: calculator) }
-    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
-    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
-    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
-    let(:product) { create(:product) }
-    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
-    let(:ups) { create(:shipping_method) }
-    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
-
-    subject { action.relevant_rules }
-
-    it { is_expected.to contain_exactly(order_rule, line_item_rule) }
-  end
 end

--- a/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/actions/adjust_shipment_spec.rb
@@ -38,20 +38,4 @@ RSpec.describe SolidusFriendlyPromotions::Actions::AdjustShipment do
 
     it { is_expected.to eq(:shipment) }
   end
-
-  describe "#relevant_rules" do
-    let!(:promotion) { create(:friendly_promotion, actions: [action], rules: rules) }
-    let(:action) { described_class.new(calculator: calculator) }
-    let(:calculator) { SolidusFriendlyPromotions::Calculators::FlatRate.new(preferred_amount: 10) }
-    let(:order_rule) { SolidusFriendlyPromotions::Rules::FirstOrder.new }
-    let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [product]) }
-    let(:product) { create(:product) }
-    let(:shipment_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [ups.id]) }
-    let(:ups) { create(:shipping_method) }
-    let(:rules) { [order_rule, line_item_rule, shipment_rule] }
-
-    subject { action.relevant_rules }
-
-    it { is_expected.to contain_exactly(order_rule, shipment_rule) }
-  end
 end

--- a/spec/models/solidus_friendly_promotions/calculators/distributed_amount_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/distributed_amount_spec.rb
@@ -6,10 +6,10 @@ require "shared_examples/calculator_shared_examples"
 RSpec.describe SolidusFriendlyPromotions::Calculators::DistributedAmount, type: :model do
   let(:calculator) { described_class.new(preferred_amount: 15, preferred_currency: currency) }
   let!(:promotion) do
-    create :friendly_promotion, apply_automatically: true, name: "15 spread", actions: [action], rules: rules
+    create :friendly_promotion, apply_automatically: true, name: "15 spread", actions: [action]
   end
-  let(:rules) { [] }
-  let(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.create(calculator: calculator) }
+  let(:conditions) { [] }
+  let(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.create(calculator: calculator, conditions: conditions) }
   let(:order) { create(:order_with_line_items, line_items_attributes: line_items_attributes) }
   let(:currency) { "USD" }
 
@@ -27,7 +27,7 @@ RSpec.describe SolidusFriendlyPromotions::Calculators::DistributedAmount, type: 
 
     context "with product promotion rule" do
       let(:first_product) { order.line_items.first.product }
-      let(:rules) do
+      let(:conditions) do
         [
           SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [first_product])
         ]

--- a/spec/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe SolidusFriendlyPromotions::Calculators::TieredPercentOnEligibleIt
 
   let(:clothes) { create(:taxon, products: [shirt.product, pants.product]) }
 
-  let(:promotion) { create(:friendly_promotion, name: "10 Percent on 5 apparel, 15 percent on 10", rules: [clothes_only], actions: [action]) }
+  let(:promotion) { create(:friendly_promotion, name: "10 Percent on 5 apparel, 15 percent on 10", actions: [action]) }
   let(:clothes_only) { SolidusFriendlyPromotions::Rules::Taxon.new(taxons: [clothes]) }
-  let(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: calculator) }
+  let(:action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: calculator, conditions: [clothes_only]) }
   let(:calculator) { described_class.new(preferred_base_percent: 10, preferred_tiers: {10 => 15.0}) }
 
   let(:line_item) { order.line_items.detect { _1.variant == shirt } }

--- a/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::EligibilityResult do
   it { is_expected.to respond_to(:item) }
+  it { is_expected.to respond_to(:condition) }
   it { is_expected.to respond_to(:success) }
   it { is_expected.to respond_to(:code) }
   it { is_expected.to respond_to(:message) }

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -6,28 +6,29 @@ RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
   subject(:eligibility_results) { described_class.new(promotion) }
 
   describe "#add" do
-    let(:promotion) { create(:friendly_promotion) }
+    let(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+    let(:promotion_action) { promotion.actions.first }
     let(:order) { create(:order, item_total: 100) }
-    let(:rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(promotion: promotion, preferred_amount: 101) }
+    let(:condition) { SolidusFriendlyPromotions::Rules::ItemTotal.new(action: promotion_action, preferred_amount: 101) }
 
     it "can add an error result" do
-      result = rule.eligible?(order)
+      result = condition.eligible?(order)
 
       eligibility_results.add(
         item: order,
-        rule: rule,
+        condition: condition,
         success: result,
-        code: rule.eligibility_errors.details[:base].first[:error_code],
-        message: rule.eligibility_errors.full_messages.first
+        code: condition.eligibility_errors.details[:base].first[:error_code],
+        message: condition.eligibility_errors.full_messages.first
       )
 
       expect(eligibility_results.to_a).to eq([
         SolidusFriendlyPromotions::EligibilityResult.new(
           item: order,
-          rule: rule,
+          condition: condition,
           success: result,
-          code: rule.eligibility_errors.details[:base].first[:error_code],
-          message: rule.eligibility_errors.full_messages.first
+          code: condition.eligibility_errors.details[:base].first[:error_code],
+          message: condition.eligibility_errors.full_messages.first
         )
       ])
     end

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
   describe "collecting eligibility results in a dry run" do
     let(:shirt) { create(:product, name: "Shirt") }
     let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}]) }
-    let(:rules) { [product_rule] }
-    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, rules: rules, name: "20% off Shirts", apply_automatically: true) }
-    let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+    let(:conditions) { [product_condition] }
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action, conditions: conditions, name: "20% off Shirts", apply_automatically: true) }
+    let(:product_condition) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
     let(:promotions) { [promotion] }
     let(:discounter) { described_class.new(order, promotions, dry_run: true) }
 
@@ -49,7 +49,7 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
 
       expect(promotion.eligibility_results.first.success).to be true
       expect(promotion.eligibility_results.first.code).to be nil
-      expect(promotion.eligibility_results.first.rule).to eq(product_rule)
+      expect(promotion.eligibility_results.first.condition).to eq(product_condition)
       expect(promotion.eligibility_results.first.message).to be nil
       expect(promotion.eligibility_results.first.item).to eq(order)
     end
@@ -59,20 +59,20 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       expect(promotion.eligibility_results.success?).to be true
     end
 
-    context "with two rules" do
-      let(:rules) { [product_rule, item_total_rule] }
-      let(:item_total_rule) { SolidusFriendlyPromotions::Rules::ItemTotal.new(preferred_amount: 2000) }
+    context "with two conditions" do
+      let(:conditions) { [product_condition, item_total_condition] }
+      let(:item_total_condition) { SolidusFriendlyPromotions::Rules::ItemTotal.new(preferred_amount: 2000) }
 
       it "will collect eligibility results" do
         subject
 
         expect(promotion.eligibility_results.first.success).to be true
         expect(promotion.eligibility_results.first.code).to be nil
-        expect(promotion.eligibility_results.first.rule).to eq(product_rule)
+        expect(promotion.eligibility_results.first.condition).to eq(product_condition)
         expect(promotion.eligibility_results.first.message).to be nil
         expect(promotion.eligibility_results.first.item).to eq(order)
         expect(promotion.eligibility_results.last.success).to be false
-        expect(promotion.eligibility_results.last.rule).to eq(item_total_rule)
+        expect(promotion.eligibility_results.last.condition).to eq(item_total_condition)
         expect(promotion.eligibility_results.last.code).to eq :item_total_less_than_or_equal
         expect(promotion.eligibility_results.last.message).to eq "This coupon code can't be applied to orders less than or equal to $2,000.00."
         expect(promotion.eligibility_results.last.item).to eq(order)
@@ -91,7 +91,7 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       end
     end
 
-    context "with an order with multiple line items and an item-level rule" do
+    context "with an order with multiple line items and an item-level condition" do
       let(:pants) { create(:product, name: "Pants") }
       let(:order) do
         create(
@@ -100,12 +100,12 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
         )
       end
 
-      let(:shirt_product_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [shirt]) }
-      let(:rules) { [shirt_product_rule] }
+      let(:shirt_product_condition) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [shirt]) }
+      let(:conditions) { [shirt_product_condition] }
 
       it "can tell us about success" do
         subject
-        # This is successful, because one of the line item rules matches
+        # This is successful, because one of the line item conditions matches
         expect(promotion.eligibility_results.success?).to be true
       end
 
@@ -114,11 +114,11 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
         expect(promotion.eligibility_results.error_messages).to be_empty
       end
 
-      context "with a second line item level rule" do
+      context "with a second line item level condition" do
         let(:hats) { create(:taxon, name: "Hats", products: [hat]) }
         let(:hat) { create(:product) }
-        let(:hat_product_rule) { SolidusFriendlyPromotions::Rules::LineItemTaxon.new(taxons: [hats]) }
-        let(:rules) { [shirt_product_rule, hat_product_rule] }
+        let(:hat_product_condition) { SolidusFriendlyPromotions::Rules::LineItemTaxon.new(taxons: [hats]) }
+        let(:conditions) { [shirt_product_condition, hat_product_condition] }
 
         it "can tell us about success" do
           subject
@@ -135,8 +135,8 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
     end
 
     context "when the order must not contain a shirt" do
-      let(:no_shirt_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_match_policy: "none", preferred_line_item_applicable: false) }
-      let(:rules) { [no_shirt_rule] }
+      let(:no_shirt_condition) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_match_policy: "none", preferred_line_item_applicable: false) }
+      let(:conditions) { [no_shirt_condition] }
 
       it "can tell us about success" do
         subject
@@ -149,15 +149,15 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       let(:usps) { create(:shipping_method) }
       let(:ups_ground) { create(:shipping_method) }
       let(:order) { create(:order_with_line_items, line_items_attributes: [{variant: shirt.master, quantity: 1}], shipping_method: ups_ground) }
-      let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
-      let(:shipping_method_rule) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [usps.id]) }
+      let(:product_condition) { SolidusFriendlyPromotions::Rules::Product.new(products: [shirt], preferred_line_item_applicable: false) }
+      let(:shipping_method_condition) { SolidusFriendlyPromotions::Rules::ShippingMethod.new(preferred_shipping_method_ids: [usps.id]) }
       let(:ten_off_items) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
       let(:ten_off_shipping) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
-      let(:shipping_action) { SolidusFriendlyPromotions::Actions::AdjustShipment.new(calculator: ten_off_shipping) }
-      let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items) }
+      let(:shipping_action) { SolidusFriendlyPromotions::Actions::AdjustShipment.new(calculator: ten_off_shipping, conditions: [product_condition]) }
+      let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items, conditions: [shipping_method_condition]) }
       let(:actions) { [shipping_action, line_item_action] }
-      let(:rules) { [product_rule, shipping_method_rule] }
-      let!(:promotion) { create(:friendly_promotion, actions: actions, rules: rules, name: "10% off Shirts and USPS Shipping", apply_automatically: true) }
+      let(:conditions) { [product_condition, shipping_method_condition] }
+      let!(:promotion) { create(:friendly_promotion, actions: actions, name: "10% off Shirts and USPS Shipping", apply_automatically: true) }
 
       it "can tell us about success" do
         subject
@@ -170,8 +170,8 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       end
     end
 
-    context "with no rules" do
-      let(:rules) { [] }
+    context "with no conditions" do
+      let(:conditions) { [] }
 
       it "has no errors for this promo" do
         subject
@@ -179,11 +179,11 @@ RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrd
       end
     end
 
-    context "with an ineligible order-level rule" do
+    context "with an ineligible order-level condition" do
       let(:mug) { create(:product) }
-      let(:order_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
-      let(:line_item_rule) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [mug]) }
-      let(:rules) { [order_rule, line_item_rule] }
+      let(:order_condition) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+      let(:line_item_condition) { SolidusFriendlyPromotions::Rules::LineItemProduct.new(products: [mug]) }
+      let(:conditions) { [order_condition, line_item_condition] }
 
       it "can tell us about success" do
         subject

--- a/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_action_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionAction do
   it { is_expected.to belong_to(:promotion) }
   it { is_expected.to have_one(:calculator) }
   it { is_expected.to have_many(:shipping_rate_discounts) }
+  it { is_expected.to have_many(:conditions) }
 
   it { is_expected.to respond_to :discount }
   it { is_expected.to respond_to :can_discount? }

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -262,10 +262,10 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
         end
 
         context "when the coupon fails to activate" do
-          let(:impossible_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+          let(:impossible_condition) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
 
           before do
-            promotion.rules << impossible_rule
+            promotion.actions.first.conditions << impossible_condition
           end
 
           it "is not successful" do

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -429,10 +429,10 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model
     let(:product_rule) { SolidusFriendlyPromotions::Rules::Product.new(products: [hat], preferred_line_item_applicable: false) }
     let(:nth_order_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
     let(:ten_off_items) { SolidusFriendlyPromotions::Calculators::Percent.create!(preferred_percent: 10) }
-    let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items) }
+    let(:line_item_action) { SolidusFriendlyPromotions::Actions::AdjustLineItem.new(calculator: ten_off_items, conditions: conditions) }
     let(:actions) { [line_item_action] }
-    let(:rules) { [product_rule, nth_order_rule] }
-    let!(:promotion) { create(:friendly_promotion, actions: actions, rules: rules, name: "10% off Shirts and USPS Shipping") }
+    let(:conditions) { [product_rule, nth_order_rule] }
+    let!(:promotion) { create(:friendly_promotion, actions: actions, name: "10% off Shirts and USPS Shipping") }
     let!(:coupon) { create(:friendly_promotion_code, promotion: promotion, value: "XMAS") }
     let(:handler) { described_class.new(order) }
 

--- a/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Page, type: :model d
   end
 
   context "when promotion is not eligible" do
-    let(:impossible_rule) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
+    let(:impossible_condition) { SolidusFriendlyPromotions::Rules::NthOrder.new(preferred_nth_order: 2) }
     before do
-      promotion.rules << impossible_rule
+      promotion.actions.first.conditions << impossible_condition
     end
 
     it "is not applied" do

--- a/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionRule do
+  it { is_expected.to belong_to(:action).optional }
   let(:bad_test_rule_class) { Class.new(SolidusFriendlyPromotions::PromotionRule) }
   let(:test_rule_class) do
     Class.new(SolidusFriendlyPromotions::PromotionRule) do

--- a/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
@@ -28,15 +28,16 @@ RSpec.describe SolidusFriendlyPromotions::PromotionRule do
     expect { test_rule_class.new.eligible?("promotable") }.not_to raise_error
   end
 
-  it "validates unique rules for a promotion" do
+  it "validates unique rules for a promotion action" do
     # Because of Rails' STI, we can't use the anonymous class here
-    promotion = create(:friendly_promotion)
+    promotion = create(:friendly_promotion, :with_adjustable_action)
+    promotion_action = promotion.actions.first
     rule_one = SolidusFriendlyPromotions::Rules::FirstOrder.new
-    rule_one.promotion_id = promotion.id
+    rule_one.action_id = promotion_action.id
     rule_one.save!
 
     rule_two = SolidusFriendlyPromotions::Rules::FirstOrder.new
-    rule_two.promotion_id = promotion.id
+    rule_two.action_id = promotion_action.id
     expect(rule_two).not_to be_valid
     expect(rule_two.errors.full_messages).to include("Promotion already contains this rule type")
   end

--- a/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_rule_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SolidusFriendlyPromotions::PromotionRule do
     rule_two = SolidusFriendlyPromotions::Rules::FirstOrder.new
     rule_two.action_id = promotion_action.id
     expect(rule_two).not_to be_valid
-    expect(rule_two.errors.full_messages).to include("Promotion already contains this rule type")
+    expect(rule_two.errors.full_messages).to include("Action already contains this rule type")
   end
 
   it "generates its own partial path" do

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
 
   it { is_expected.to belong_to(:category).optional }
   it { is_expected.to respond_to(:customer_label) }
-  it { is_expected.to have_many :rules }
+  it { is_expected.to have_many :conditions }
   it { is_expected.to have_many(:order_promotions).dependent(:destroy) }
   it { is_expected.to have_many(:code_batches).dependent(:destroy) }
 
@@ -513,13 +513,14 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   end
 
   describe "#products" do
-    let(:promotion) { create(:friendly_promotion) }
+    let(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+    let(:promotion_action) { promotion.actions.first }
 
     context "when it has product rules with products associated" do
       let(:promotion_rule) { SolidusFriendlyPromotions::Rules::Product.new }
 
       before do
-        promotion_rule.promotion = promotion
+        promotion_rule.action = promotion_action
         promotion_rule.products << create(:product)
         promotion_rule.save
       end

--- a/spec/models/solidus_friendly_promotions/rules/shipping_method_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/shipping_method_spec.rb
@@ -4,16 +4,17 @@ require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Rules::ShippingMethod, type: :model do
   let(:rule) { described_class.new }
+  let!(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+  let(:promotion_action) { promotion.actions.first }
+  let(:ups_ground) { create(:shipping_method) }
+  let(:dhl_saver) { create(:shipping_method) }
 
   it { is_expected.to respond_to(:preferred_shipping_method_ids) }
 
   describe "preferred_shipping_methods_ids=" do
     subject { rule.preferred_shipping_method_ids = [ups_ground.id] }
 
-    let!(:promotion) { create(:friendly_promotion) }
-    let(:ups_ground) { create(:shipping_method) }
-    let(:dhl_saver) { create(:shipping_method) }
-    let(:rule) { promotion.rules.build(type: described_class.to_s) }
+    let(:rule) { promotion_action.conditions.build(type: described_class.to_s) }
 
     it "creates a valid rule with a shipping method" do
       subject
@@ -25,10 +26,7 @@ RSpec.describe SolidusFriendlyPromotions::Rules::ShippingMethod, type: :model do
   describe "#eligible?" do
     subject { rule.eligible?(promotable) }
 
-    let!(:promotion) { create(:friendly_promotion) }
-    let(:ups_ground) { create(:shipping_method) }
-    let(:dhl_saver) { create(:shipping_method) }
-    let(:rule) { promotion.rules.build(type: described_class.to_s, preferred_shipping_method_ids: [ups_ground.id]) }
+    let(:rule) { promotion_action.conditions.build(type: described_class.to_s, preferred_shipping_method_ids: [ups_ground.id]) }
 
     context "with a shipment" do
       context "when the shipment has the right shipping method selected" do

--- a/spec/models/solidus_friendly_promotions/rules/store_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/store_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe SolidusFriendlyPromotions::Rules::Store, type: :model do
   describe "store_ids=" do
     subject { rule.store_ids = [store.id] }
 
-    let!(:promotion) { create(:friendly_promotion) }
+    let!(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+    let(:promotion_action) { promotion.actions.first }
     let!(:unimportant_store) { create(:store) }
     let!(:store) { create(:store) }
-    let(:rule) { promotion.rules.build(type: described_class.to_s) }
+    let(:rule) { promotion_action.conditions.build(type: described_class.to_s) }
 
     it "creates a valid rule with a store" do
       subject

--- a/spec/models/solidus_friendly_promotions/rules/taxon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/taxon_spec.rb
@@ -3,8 +3,10 @@
 require "spec_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Rules::Taxon, type: :model do
+  let(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+  let(:promotion_action) { promotion.actions.first }
   let(:rule) do
-    described_class.create!(promotion: create(:friendly_promotion))
+    described_class.create!(action: promotion_action)
   end
   let(:product) { order.products.first }
   let(:order) { create :order_with_line_items }
@@ -16,9 +18,7 @@ RSpec.describe SolidusFriendlyPromotions::Rules::Taxon, type: :model do
   describe "taxon_ids_string=" do
     subject { rule.assign_attributes("taxon_ids_string" => taxon_two.id.to_s) }
 
-    let!(:promotion) { create(:friendly_promotion) }
-
-    let(:rule) { promotion.rules.build(type: described_class.to_s) }
+    let(:rule) { promotion_action.conditions.build(type: described_class.to_s) }
 
     it "creates a valid rule with a taxon" do
       subject

--- a/spec/models/solidus_friendly_promotions/rules/user_spec.rb
+++ b/spec/models/solidus_friendly_promotions/rules/user_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe SolidusFriendlyPromotions::Rules::User, type: :model do
   describe "user_ids=" do
     subject { rule.user_ids = [user.id] }
 
-    let(:promotion) { create(:friendly_promotion) }
+    let(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+    let(:action) { promotion.actions.first }
     let(:user) { create(:user) }
-    let(:rule) { promotion.rules.new }
+    let(:rule) { described_class.new(users: [user], action: action) }
 
     it "creates a valid rule with a user" do
       expect(rule).to be_valid

--- a/spec/requests/solidus_friendly_promotions/admin/promotion_rules_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/admin/promotion_rules_request_spec.rb
@@ -25,7 +25,7 @@ describe "Admin::PromotionRules", type: :request do
       }
       expect(response).to be_redirect
       expect(response).to redirect_to solidus_friendly_promotions.edit_admin_promotion_path(promotion)
-      expect(promotion.rules.count).to eq(0)
+      expect(promotion_action.conditions.count).to eq(0)
     end
   end
 

--- a/spec/requests/solidus_friendly_promotions/admin/promotion_rules_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/admin/promotion_rules_request_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 describe "Admin::PromotionRules", type: :request do
-  let!(:promotion) { create(:friendly_promotion) }
+  let!(:promotion) { create(:friendly_promotion, :with_adjustable_action) }
+  let(:promotion_action) { promotion.actions.first }
 
   context "when the user is authorized" do
     stub_authorization! do |_u|
@@ -11,16 +12,16 @@ describe "Admin::PromotionRules", type: :request do
     end
 
     it "can create a promotion rule of a valid type" do
-      post solidus_friendly_promotions.admin_promotion_promotion_rules_path(promotion_id: promotion.id), params: {
+      post solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rules_path(promotion, promotion_action), params: {
         promotion_rule: {type: "SolidusFriendlyPromotions::Rules::Product"}
       }
       expect(response).to be_redirect
       expect(response).to redirect_to solidus_friendly_promotions.edit_admin_promotion_path(promotion)
-      expect(promotion.rules.count).to eq(1)
+      expect(promotion_action.conditions.count).to eq(1)
     end
 
     it "can not create a promotion rule of an invalid type" do
-      post solidus_friendly_promotions.admin_promotion_promotion_rules_path(promotion_id: promotion.id), params: {
+      post solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rules_path(promotion, promotion_action), params: {
         promotion_rule: {type: "Spree::InvalidType"}
       }
       expect(response).to be_redirect
@@ -31,7 +32,7 @@ describe "Admin::PromotionRules", type: :request do
 
   context "when the user is not authorized" do
     it "redirects the user to login" do
-      post solidus_friendly_promotions.admin_promotion_promotion_rules_path(promotion_id: promotion.id), params: {
+      post solidus_friendly_promotions.admin_promotion_promotion_action_promotion_rules_path(promotion, promotion_action), params: {
         promotion_rule: {type: "SolidusFriendlyPromotions::Rules::Product"}
       }
       expect(response).to redirect_to("/admin/login")

--- a/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
+++ b/spec/system/solidus_friendly_promotions/admin/promotions_spec.rb
@@ -110,36 +110,6 @@ RSpec.describe "Promotions admin", type: :system do
       click_button("Create")
       expect(page).to have_content("March 2023 Giveaway")
       promotion = SolidusFriendlyPromotions::Promotion.first
-      within("#new_order_promotion_rule_promotion_#{promotion.id}") do
-        click_link("New Rule")
-        select("First Order", from: "Type")
-        click_button("Add")
-      end
-      expect(page).to have_content("Must be the customer's first order")
-      expect(SolidusFriendlyPromotions::PromotionRule.first).to be_a(SolidusFriendlyPromotions::Rules::FirstOrder)
-      promotion_rule = promotion.rules.first
-      within("#rules_first_order_#{promotion_rule.id}") do
-        find(".delete").click
-      end
-      expect(page).not_to have_content("Must be the customer's first order")
-      expect(promotion.rules).to be_empty
-
-      within("#new_order_promotion_rule_promotion_#{promotion.id}") do
-        click_link("New Rule")
-        select("Item Total", from: "Type")
-        fill_in("promotion_rule_preferred_amount", with: 200)
-        click_button("Add")
-      end
-
-      expect(page).to have_content("Order total meets these criteria")
-
-      promotion_rule = promotion.rules.first
-      within("#rules_item_total_#{promotion_rule.id}") do
-        expect(find("#promotion_rule_preferred_amount").value).to eq("200.00")
-        fill_in("promotion_rule_preferred_amount", with: 300)
-        click_button("Update")
-        expect(find("#promotion_rule_preferred_amount").value).to eq("300.00")
-      end
 
       within("#new_promotion_action_promotion_#{promotion.id}") do
         click_link("New Action")
@@ -156,6 +126,33 @@ RSpec.describe "Promotions admin", type: :system do
         click_button("Update")
       end
       expect(action.reload.calculator.preferred_amount).to eq(30)
+
+      click_link("New Rule")
+      select("First Order", from: "Type")
+      click_button("Add")
+      expect(page).to have_content("Must be the customer's first order")
+      expect(SolidusFriendlyPromotions::PromotionRule.first).to be_a(SolidusFriendlyPromotions::Rules::FirstOrder)
+      promotion_rule = promotion.actions.first.conditions.first
+      within("#rules_first_order_#{promotion_rule.id}") do
+        find(".delete").click
+      end
+      expect(page).not_to have_content("Must be the customer's first order")
+      expect(promotion.conditions).to be_empty
+
+      click_link("New Rule")
+      select("Item Total", from: "Type")
+      fill_in("promotion_rule_preferred_amount", with: 200)
+      click_button("Add")
+
+      expect(page).to have_content("Order total meets these criteria")
+
+      promotion_rule = promotion.actions.first.conditions.first
+      within("#rules_item_total_#{promotion_rule.id}") do
+        expect(find("#promotion_rule_preferred_amount").value).to eq("200.00")
+        fill_in("promotion_rule_preferred_amount", with: 300)
+        click_button("Update")
+        expect(find("#promotion_rule_preferred_amount").value).to eq("300.00")
+      end
 
       within("#actions_adjust_line_item_#{action.id}_promotion_#{promotion.id}") do
         find(".delete").click


### PR DESCRIPTION
This rather large change switches the association of promotion rules from the promotion to the promotion action. 

The rationale is: Most promotions have exactly one action, and things become much easier if every action has its own set of rules. We can't have dangling rules anymore when deleting all actions (they don't mean anything then), and we don't have to decide which rules apply to which action. 

Note that this commit foreshadows a renaming that's coming up, in which promotion "rules" are going to be renamed "conditions". 

Closes #87 