### PR TITLE
Include Discarded Promotions

### DIFF
--- a/app/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions.rb
+++ b/app/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions.rb
@@ -30,13 +30,13 @@ module SolidusFriendlyPromotions
 
       def connected_order_promotions
         eligible_connected_promotion_ids = order.friendly_order_promotions.select do |order_promotion|
-          order_promotion.promotion_code.nil? || !order_promotion.promotion_code.usage_limit_exceeded?(excluded_orders: [order])
+          order_promotion.promotion.kept? && (order_promotion.promotion_code.nil? || !order_promotion.promotion_code.usage_limit_exceeded?(excluded_orders: [order]))
         end.map(&:promotion_id)
         order.friendly_promotions.active(reference_time).where(id: eligible_connected_promotion_ids).includes(promotion_includes)
       end
 
       def sale_promotions
-        SolidusFriendlyPromotions::Promotion.where(apply_automatically: true).active(reference_time).includes(promotion_includes)
+        SolidusFriendlyPromotions::Promotion.kept.where(apply_automatically: true).active(reference_time).includes(promotion_includes)
       end
 
       def reference_time

--- a/app/models/solidus_friendly_promotions/order_promotion.rb
+++ b/app/models/solidus_friendly_promotions/order_promotion.rb
@@ -7,7 +7,7 @@ module SolidusFriendlyPromotions
   # 2. The specific code that they used
   class OrderPromotion < Spree::Base
     belongs_to :order, class_name: "Spree::Order"
-    belongs_to :promotion, class_name: "SolidusFriendlyPromotions::Promotion"
+    belongs_to :promotion, -> { with_discarded }, class_name: "SolidusFriendlyPromotions::Promotion"
     belongs_to :promotion_code, class_name: "SolidusFriendlyPromotions::PromotionCode", optional: true
 
     validates :promotion_code, presence: true, if: :require_promotion_code?

--- a/app/models/solidus_friendly_promotions/promotion.rb
+++ b/app/models/solidus_friendly_promotions/promotion.rb
@@ -22,6 +22,7 @@ module SolidusFriendlyPromotions
     validate :apply_automatically_disallowed_with_promotion_codes
 
     before_save :normalize_blank_values
+    after_discard :delete_cart_connections
 
     scope :active, ->(time = Time.current) { has_benefits.started_and_unexpired(time) }
     scope :advertised, -> { where(advertise: true) }
@@ -148,6 +149,10 @@ module SolidusFriendlyPromotions
       return unless apply_automatically
 
       errors.add(:apply_automatically, :disallowed_with_promotion_codes) if codes.present?
+    end
+
+    def delete_cart_connections
+      order_promotions.where(order: Spree::Order.incomplete).destroy_all
     end
   end
 end

--- a/app/models/solidus_friendly_promotions/promotion_code.rb
+++ b/app/models/solidus_friendly_promotions/promotion_code.rb
@@ -2,7 +2,7 @@
 
 module SolidusFriendlyPromotions
   class PromotionCode < Spree::Base
-    belongs_to :promotion, inverse_of: :codes
+    belongs_to :promotion, -> { with_discarded }, inverse_of: :codes
     belongs_to :promotion_code_batch, inverse_of: :promotion_codes, optional: true
 
     has_many :order_promotions, class_name: "SolidusFriendlyPromotions::OrderPromotion", dependent: :destroy

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
 
     subject { promotion.destroy! }
 
-    it "destroys the promotion and nullifies the benefit" do
+    it "destroys the promotion and deletes the benefit" do
       expect { subject }.to change { SolidusFriendlyPromotions::Promotion.count }.by(-1)
       expect(SolidusFriendlyPromotions::Benefit.count).to be_zero
     end
@@ -39,6 +39,19 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
 
       it "raises an error" do
         expect { subject }.to raise_exception(ActiveRecord::RecordNotDestroyed)
+      end
+    end
+
+    context "when the promotion has been added to an incomplete order" do
+      let!(:promotion) { create(:friendly_promotion, :with_adjustable_benefit) }
+      let(:order) { create(:order) }
+
+      before do
+        order.friendly_promotions << promotion
+      end
+
+      it "destroys the connection" do
+        expect { subject }.to change(SolidusFriendlyPromotions::OrderPromotion, :count).by(-1)
       end
     end
   end

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   end
 
   describe "#apply_automatically" do
-    subject { build(:friendly_promotion) }
+    subject { create(:friendly_promotion) }
 
     it "defaults to false" do
       expect(subject.apply_automatically).to eq(false)


### PR DESCRIPTION
When applying or validating a promotion, we load all associated promotions through order_promotions and check their usage limit. A discarded promotion can still be associated with an order. If we do not load discarded promotions, then the order_promotion will not have an associated promotion and checking usage limits will result in an error.