### PR TITLE
Only build on Ruby 3.3.2 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: '3.3'
+      ruby_version: '3.3.2'
     steps:
       - browser-tools/install-chrome
       - checkout


### PR DESCRIPTION
3.3.3 has weird issues, see https://stackoverflow.com/questions/78617432/strange-bundle-update-issue-disappearing-net-pop-0-1-2-dependency