### PR TITLE
Miscellaneous spec fixes

### DIFF
--- a/app/jobs/solidus_friendly_promotions/promotion_code_batch_job.rb
+++ b/app/jobs/solidus_friendly_promotions/promotion_code_batch_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusFriendlyPromotions
-  class PromotionCodeBatchJob < ApplicationJob
+  class PromotionCodeBatchJob < ActiveJob::Base
     queue_as :default
 
     def perform(promotion_code_batch)

--- a/spec/models/solidus_friendly_promotions/promotion_code/batch_builder_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_code/batch_builder_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe SolidusFriendlyPromotions::PromotionCode::BatchBuilder do
 
     context "with a successful build" do
       before do
-        allow(Spree::PromotionCodeBatchMailer)
-          .to receive(:code_batch_finished)
+        allow(SolidusFriendlyPromotions::PromotionCodeBatchMailer)
+          .to receive(:promotion_code_batch_finished)
           .and_call_original
 
         subject.build_promotion_codes

--- a/spec/requests/solidus_friendly_promotions/admin/benefits_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/admin/benefits_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin::Benefits", type: :request do
+RSpec.describe "Admin::Benefits", type: :request do
   stub_authorization!
 
   let!(:promotion) { create(:friendly_promotion) }

--- a/spec/requests/solidus_friendly_promotions/admin/conditions_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/admin/conditions_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin::Conditions", type: :request do
+RSpec.describe "Admin::Conditions", type: :request do
   let!(:promotion) { create(:friendly_promotion, :with_adjustable_benefit) }
   let(:benefit) { promotion.benefits.first }
 

--- a/spec/requests/solidus_friendly_promotions/admin/conditions_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/admin/conditions_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Admin::Conditions", type: :request do
 
   context "when the user is authorized" do
     stub_authorization! do |_u|
-      Spree::PermissionSets::PromotionManagement.new(self).activate!
+      SolidusFriendlyPromotions::PermissionSets::PromotionManagement.new(self).activate!
     end
 
     it "can create a promotion condition of a valid type" do
@@ -35,7 +35,7 @@ RSpec.describe "Admin::Conditions", type: :request do
       post solidus_friendly_promotions.admin_promotion_benefit_conditions_path(promotion, benefit), params: {
         condition: {type: "SolidusFriendlyPromotions::Conditions::Product"}
       }
-      expect(response).to redirect_to("/admin/login")
+      expect(response).to be_redirect
     end
   end
 end

--- a/spec/system/solidus_friendly_promotions/admin/promotion_categories_spec.rb
+++ b/spec/system/solidus_friendly_promotions/admin/promotion_categories_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Promotion Categories", type: :system do
+RSpec.describe "Promotion Categories", type: :system do
   stub_authorization!
 
   context "index" do

--- a/spec/system/solidus_friendly_promotions/admin/promotion_code_batches_spec.rb
+++ b/spec/system/solidus_friendly_promotions/admin/promotion_code_batches_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-feature "Promotion Code Batches", partial_double_verification: false do
+RSpec.feature "Promotion Code Batches", partial_double_verification: false do
   stub_authorization!
 
   describe "create" do


### PR DESCRIPTION
This fixes a bunch of specs that only work because certain conditions are true: 

- we allow RSpec's DSL in the root namespace, even though we didn't do that at the very beginning. Add `RSpec.` for clarity.
- in some specs we used objects of the legacy promotions gem. We obviously want to test/mock our own code. 
- A `standardrb --fix` has made a job inherit from `ApplicationJob` even though we don't have `ApplicationJob` as this is a library. 