### PR TITLE
Allow Turbo 2.x, but fix its issues

### DIFF
--- a/solidus_friendly_promotions.gemspec
+++ b/solidus_friendly_promotions.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "solidus_core", [">= 4.0.0", "< 5"]
   spec.add_dependency "solidus_support", "~> 0.5"
-  spec.add_dependency "turbo-rails", "~> 1.4"
+  spec.add_dependency "turbo-rails", ">= 1.4"
   spec.add_dependency "stimulus-rails", "~> 1.2"
   spec.add_dependency "importmap-rails", "~> 1.2"
   spec.add_dependency "ransack-enum", "~> 1.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,11 @@ Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 # See: lib/solidus_friendly_promotions/testing_support/factories.rb
 SolidusDevSupport::TestingSupport::Factories.load_for(SolidusFriendlyPromotions::Engine)
 
+# Turbo will try to autoload ActionCable if we allow `app/channels`.
+# Backport of https://github.com/hotwired/turbo-rails/pull/601
+# Can go once `turbo-rails` 2.0.7 is released.
+Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
+
 Spree::Config.promotions = SolidusFriendlyPromotions.configuration
 
 RSpec.configure do |config|


### PR DESCRIPTION
This extension is mostly compatible with Turbo 2. However, Turbo 2 references ActionCable in its `app/channels` folder, and that breaks eager loading for our dummy app (which doesn't have ActionCable). 