### PR TITLE
Use single-file dummy app from Solidus core

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
+require "rubygems"
+require "rake"
+require "rake/testtask"
+require "rspec/core/rake_task"
+require "spree/testing_support/dummy_app/rake_tasks"
 require "bundler/gem_tasks"
-require "solidus_dev_support/rake_tasks"
-SolidusDevSupport::RakeTasks.install
 
-task default: "extension:specs"
+RSpec::Core::RakeTask.new
+task default: :spec
+
+DummyApp::RakeTasks.new(
+  gem_root: File.dirname(__FILE__),
+  lib_name: "solidus_friendly_promotions"
+)
+
+task test_app: "db:reset"

--- a/solidus_friendly_promotions.gemspec
+++ b/solidus_friendly_promotions.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "importmap-rails", "~> 1.2"
   spec.add_dependency "ransack-enum", "~> 1.0"
   spec.add_development_dependency "rspec-activemodel-mocks", "~> 1.0"
+  spec.add_development_dependency "rspec-retry"
   spec.add_development_dependency "shoulda-matchers", "~> 5.3"
   spec.add_development_dependency "solidus_dev_support", "~> 2.6"
   spec.add_development_dependency "standard", "~> 1.31"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,10 +5,21 @@ ENV["RAILS_ENV"] = "test"
 
 require "spec_helper"
 
-# Create the dummy app if it's still missing.
-dummy_env = "#{__dir__}/dummy/config/environment.rb"
-system "bin/rake extension:test_app" unless File.exist? dummy_env
-require dummy_env
+# Run Coverage report
+require "solidus_dev_support/rspec/coverage"
+# SOLIDUS DUMMY APP
+require "spree/testing_support/dummy_app"
+DummyApp.setup(
+  gem_root: File.expand_path("..", __dir__),
+  lib_name: "solidus_friendly_promotions"
+)
+
+# Calling `draw` will completely rewrite the routes defined in the dummy app,
+# so we need to include the main solidus route.
+DummyApp::Application.routes.draw do
+  mount SolidusFriendlyPromotions::Engine, at: "/"
+  mount Spree::Core::Engine, at: "/"
+end
 
 # Turbo will try to autoload ActionCable if we allow `app/channels`.
 # Backport of https://github.com/hotwired/turbo-rails/pull/601

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require "spec_helper"
+require "solidus_legacy_promotions"
 
 # Run Coverage report
 require "solidus_dev_support/rspec/coverage"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 
 require "rspec/core"
 
+require "spree/testing_support/flaky"
 require "spree/testing_support/partial_double_verification"
 require "spree/testing_support/silence_deprecations"
 require "spree/testing_support/preferences"


### PR DESCRIPTION
This changes the spec setup to use the `DummyApp` that Solidus core provides. This makes testing easier and faster, and it also mirrors the setup of the gems within the `solidusio/solidus` repository. Since we want to integrate this gem there soon, it makes sense to already mirror the structures needed there. 

This includes the work from #123 , #122, and #121.

