### PR TITLE
Split rails_helper and spec_helper

### DIFF
--- a/spec/jobs/solidus_friendly_promotions/promotion_code_batch_job_spec.rb
+++ b/spec/jobs/solidus_friendly_promotions/promotion_code_batch_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 RSpec.describe SolidusFriendlyPromotions::PromotionCodeBatchJob, type: :job do
   let(:email) { "test@email.com" }
   let(:code_batch) do

--- a/spec/lib/solidus_friendly_promotions/configuration_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/configuration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Configuration do
   subject(:config) { SolidusFriendlyPromotions.config }

--- a/spec/lib/solidus_friendly_promotions/migrate_adjustments_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/migrate_adjustments_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "solidus_friendly_promotions/promotion_migrator"
 require "solidus_friendly_promotions/promotion_map"
 require "solidus_friendly_promotions/migrate_adjustments"

--- a/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/migrate_order_promotions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "solidus_friendly_promotions/promotion_migrator"
 require "solidus_friendly_promotions/promotion_map"
 require "solidus_friendly_promotions/migrate_order_promotions"

--- a/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/promotion_migrator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "solidus_friendly_promotions/promotion_migrator"
 require "solidus_friendly_promotions/promotion_map"
 

--- a/spec/lib/solidus_friendly_promotions/testing_support/factories_spec.rb
+++ b/spec/lib/solidus_friendly_promotions/testing_support/factories_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Friendly Factories" do
   it "has a bunch of working factories" do

--- a/spec/mailers/solidus_friendly_promotions/promotion_code_batch_mailer_spec.rb
+++ b/spec/mailers/solidus_friendly_promotions/promotion_code_batch_mailer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionCodeBatchMailer, type: :mailer do
   let(:promotion) { create(:friendly_promotion, name: "Promotion Test") }

--- a/spec/models/promotion/integration_spec.rb
+++ b/spec/models/promotion/integration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "solidus_friendly_promotions/promotion_map"
 require "solidus_friendly_promotions/promotion_migrator"
 

--- a/spec/models/solidus_friendly_promotions/benefit_spec.rb
+++ b/spec/models/solidus_friendly_promotions/benefit_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Benefit do
   it { is_expected.to belong_to(:promotion) }

--- a/spec/models/solidus_friendly_promotions/benefits/adjust_line_item_quantity_groups_spec.rb
+++ b/spec/models/solidus_friendly_promotions/benefits/adjust_line_item_quantity_groups_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Benefits::AdjustLineItemQuantityGroups do
   let(:action) { described_class.create!(calculator: calculator, promotion: promotion) }

--- a/spec/models/solidus_friendly_promotions/benefits/adjust_line_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/benefits/adjust_line_item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Benefits::AdjustLineItem do
   subject(:action) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/benefits/adjust_shipment_spec.rb
+++ b/spec/models/solidus_friendly_promotions/benefits/adjust_shipment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Benefits::AdjustShipment do
   subject(:action) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/benefits/create_discounted_item_spec.rb
+++ b/spec/models/solidus_friendly_promotions/benefits/create_discounted_item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Benefits::CreateDiscountedItem do
   it { is_expected.to respond_to(:preferred_variant_id) }

--- a/spec/models/solidus_friendly_promotions/calculators/distributed_amount_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/distributed_amount_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::DistributedAmount, type: :model do

--- a/spec/models/solidus_friendly_promotions/calculators/flat_rate_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/flat_rate_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::FlatRate, type: :model do

--- a/spec/models/solidus_friendly_promotions/calculators/flexi_rate_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/flexi_rate_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::FlexiRate, type: :model do

--- a/spec/models/solidus_friendly_promotions/calculators/percent_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/percent_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::Percent, type: :model do

--- a/spec/models/solidus_friendly_promotions/calculators/tiered_flat_rate_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/tiered_flat_rate_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::TieredFlatRate, type: :model do

--- a/spec/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::TieredPercentOnEligibleItemQuantity do
   let(:order) do

--- a/spec/models/solidus_friendly_promotions/calculators/tiered_percent_spec.rb
+++ b/spec/models/solidus_friendly_promotions/calculators/tiered_percent_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusFriendlyPromotions::Calculators::TieredPercent, type: :model do

--- a/spec/models/solidus_friendly_promotions/condition_product.rb
+++ b/spec/models/solidus_friendly_promotions/condition_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ConditionProduct do
   it { is_expected.to belong_to(:product).optional }

--- a/spec/models/solidus_friendly_promotions/condition_spec.rb
+++ b/spec/models/solidus_friendly_promotions/condition_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Condition do
   it { is_expected.to belong_to(:benefit).optional }

--- a/spec/models/solidus_friendly_promotions/condition_store_spec.rb
+++ b/spec/models/solidus_friendly_promotions/condition_store_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ConditionStore do
   it { is_expected.to belong_to(:store).optional }

--- a/spec/models/solidus_friendly_promotions/condition_taxon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/condition_taxon_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ConditionTaxon do
   it { is_expected.to belong_to(:taxon).optional }

--- a/spec/models/solidus_friendly_promotions/condition_user_spec.rb
+++ b/spec/models/solidus_friendly_promotions/condition_user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ConditionUser do
   it { is_expected.to belong_to(:user).optional }

--- a/spec/models/solidus_friendly_promotions/conditions/discounted_item_total_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/discounted_item_total_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::DiscountedItemTotal, type: :model do
   let(:condition) do

--- a/spec/models/solidus_friendly_promotions/conditions/first_order_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/first_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::FirstOrder, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/first_repeat_purchase_since_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/first_repeat_purchase_since_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::FirstRepeatPurchaseSince do
   describe "#applicable?" do

--- a/spec/models/solidus_friendly_promotions/conditions/item_total_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/item_total_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::ItemTotal, type: :model do
   let(:condition) do

--- a/spec/models/solidus_friendly_promotions/conditions/line_item_product_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/line_item_product_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::LineItemProduct, type: :model do
   let(:condition) { described_class.new(condition_options) }

--- a/spec/models/solidus_friendly_promotions/conditions/line_item_taxon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/line_item_taxon_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::LineItemTaxon, type: :model do
   let(:taxon) { create :taxon, name: "first" }

--- a/spec/models/solidus_friendly_promotions/conditions/nth_order_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/nth_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::NthOrder do
   describe "#applicable?" do

--- a/spec/models/solidus_friendly_promotions/conditions/one_use_per_user_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/one_use_per_user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::OneUsePerUser, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/option_value_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/option_value_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::OptionValue do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/product_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/product_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::Product, type: :model do
   let(:condition_options) { {} }

--- a/spec/models/solidus_friendly_promotions/conditions/shipping_method_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/shipping_method_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::ShippingMethod, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/store_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/store_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::Store, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/taxon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/taxon_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::Taxon, type: :model do
   let(:promotion) { create(:friendly_promotion, :with_adjustable_benefit) }

--- a/spec/models/solidus_friendly_promotions/conditions/user_logged_in_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/user_logged_in_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::UserLoggedIn, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/conditions/user_role_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/user_role_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::UserRole, type: :model do
   subject { condition }

--- a/spec/models/solidus_friendly_promotions/conditions/user_spec.rb
+++ b/spec/models/solidus_friendly_promotions/conditions/user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Conditions::User, type: :model do
   let(:condition) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/distributed_amounts_handler_spec.rb
+++ b/spec/models/solidus_friendly_promotions/distributed_amounts_handler_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::DistributedAmountsHandler, type: :model do
   let(:order) do

--- a/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_result_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::EligibilityResult do
   it { is_expected.to respond_to(:item) }

--- a/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
+++ b/spec/models/solidus_friendly_promotions/eligibility_results_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::EligibilityResults do
   subject(:eligibility_results) { described_class.new(promotion) }

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/choose_discounts_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/choose_discounts_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::ChooseDiscounts do
   subject { described_class.new(discounts).call }

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/discount_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::DiscountOrder do
   context "shipped orders" do

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster/load_promotions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster::LoadPromotions do
   describe "selecting promotions" do

--- a/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster_spec.rb
+++ b/spec/models/solidus_friendly_promotions/friendly_promotion_adjuster_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::FriendlyPromotionAdjuster, type: :model do
   subject(:discounter) { described_class.new(order) }

--- a/spec/models/solidus_friendly_promotions/item_discount_spec.rb
+++ b/spec/models/solidus_friendly_promotions/item_discount_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ItemDiscount do
   it { is_expected.to respond_to(:item) }

--- a/spec/models/solidus_friendly_promotions/migration_support/order_promotion_syncer_spec.rb
+++ b/spec/models/solidus_friendly_promotions/migration_support/order_promotion_syncer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::MigrationSupport::OrderPromotionSyncer do
   subject(:syncer) { described_class.new(order: order).call }

--- a/spec/models/solidus_friendly_promotions/order_promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/order_promotion_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::OrderPromotion do
   subject do

--- a/spec/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
+++ b/spec/models/solidus_friendly_promotions/permission_sets/friendly_promotion_management.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 require "cancan/matchers"
 
 RSpec.describe SolidusFriendlyPromotions::PermissionSets::FriendlyPromotionManagement do

--- a/spec/models/solidus_friendly_promotions/promotion_advertiser_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_advertiser_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionAdvertiser, type: :model do
   describe ".for_product" do

--- a/spec/models/solidus_friendly_promotions/promotion_category_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_category_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionCategory, type: :model do
   it { is_expected.to have_many :promotions }

--- a/spec/models/solidus_friendly_promotions/promotion_code/batch_builder_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_code/batch_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionCode::BatchBuilder do
   subject { described_class.new(code_batch, options) }

--- a/spec/models/solidus_friendly_promotions/promotion_code_batch_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_code_batch_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionCodeBatch, type: :model do
   subject do

--- a/spec/models/solidus_friendly_promotions/promotion_code_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_code_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionCode do
   let(:promotion) { create(:friendly_promotion) }

--- a/spec/models/solidus_friendly_promotions/promotion_finder_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_finder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionFinder do
   describe ".by_code_or_id" do

--- a/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/coupon_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Coupon, type: :model do
   let(:order) { double("Order", coupon_code: "10off").as_null_object }

--- a/spec/models/solidus_friendly_promotions/promotion_handler/null_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/null_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Null do
   let(:order) { double }

--- a/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_handler/page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::PromotionHandler::Page, type: :model do
   subject { described_class.new(order, path).activate }

--- a/spec/models/solidus_friendly_promotions/promotion_spec.rb
+++ b/spec/models/solidus_friendly_promotions/promotion_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::Promotion, type: :model do
   let(:promotion) { described_class.new }

--- a/spec/models/solidus_friendly_promotions/shipping_rate_discount_spec.rb
+++ b/spec/models/solidus_friendly_promotions/shipping_rate_discount_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::ShippingRateDiscount do
   subject(:shipping_rate_discount) { build(:friendly_shipping_rate_discount) }

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::Adjustment do
   describe ".promotion" do

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::LineItem do
   it { is_expected.to belong_to(:managed_by_order_benefit).optional }

--- a/spec/models/spree/order_recalculator_spec.rb
+++ b/spec/models/spree/order_recalculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::Config.order_recalculator_class do
   let(:order) { create(:order) }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::Order do
   it { is_expected.to have_many :friendly_promotions }

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::Shipment do
   describe "#discountable_amount" do

--- a/spec/models/spree/shipping_rate_spec.rb
+++ b/spec/models/spree/shipping_rate_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe Spree::ShippingRate do
   let(:subject) { build(:shipping_rate) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Configure Rails Environment
+ENV["RAILS_ENV"] = "test"
+
+require "spec_helper"
+
+# Create the dummy app if it's still missing.
+dummy_env = "#{__dir__}/dummy/config/environment.rb"
+system "bin/rake extension:test_app" unless File.exist? dummy_env
+require dummy_env
+
+# Turbo will try to autoload ActionCable if we allow `app/channels`.
+# Backport of https://github.com/hotwired/turbo-rails/pull/601
+# Can go once `turbo-rails` 2.0.7 is released.
+Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
+
+# Requires factories and other useful helpers defined in spree_core.
+require "solidus_dev_support/rspec/feature_helper"
+require "shoulda-matchers"
+# Explicitly load activemodel mocks
+require "rspec-activemodel-mocks"
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
+
+# Requires factories defined in Solidus core and this extension.
+# See: lib/solidus_friendly_promotions/testing_support/factories.rb
+SolidusDevSupport::TestingSupport::Factories.load_for(SolidusFriendlyPromotions::Engine)
+
+Spree::Config.promotions = SolidusFriendlyPromotions.configuration
+
+RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = true
+
+  config.include SolidusFriendlyPromotions::Engine.routes.url_helpers, type: :request
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/solidus_friendly_promotions/api/checkout_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/api/checkout_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Api Feature Specs", type: :request do
   before do

--- a/spec/requests/solidus_friendly_promotions/backend/benefits_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/backend/benefits_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Admin::Benefits", type: :request do
   stub_authorization!

--- a/spec/requests/solidus_friendly_promotions/backend/conditions_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/backend/conditions_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Admin::Conditions", type: :request do
   let!(:promotion) { create(:friendly_promotion, :with_adjustable_benefit) }

--- a/spec/requests/solidus_friendly_promotions/backend/promotions_request_spec.rb
+++ b/spec/requests/solidus_friendly_promotions/backend/promotions_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Admin::Promotions", type: :request do
   describe "GET /index" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,47 +1,46 @@
 # frozen_string_literal: true
 
-# Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
+if ENV["COVERAGE"]
+  require "simplecov"
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name("solidus:core")
+  SimpleCov.merge_timeout(3600)
+  SimpleCov.start("rails")
+end
 
-# Run Coverage report
-require "solidus_dev_support/rspec/coverage"
+require "rspec/core"
 
-# Create the dummy app if it's still missing.
-dummy_env = "#{__dir__}/dummy/config/environment.rb"
-system "bin/rake extension:test_app" unless File.exist? dummy_env
-require dummy_env
+require "spree/testing_support/partial_double_verification"
+require "spree/testing_support/silence_deprecations"
+require "spree/testing_support/preferences"
+require "spree/deprecator"
+require "spree/core/version"
+require "spree/config"
 
-# Requires factories and other useful helpers defined in spree_core.
-require "solidus_dev_support/rspec/feature_helper"
-require "shoulda-matchers"
-# Explicitly load activemodel mocks
-require "rspec-activemodel-mocks"
-
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
-
-# Requires factories defined in Solidus core and this extension.
-# See: lib/solidus_friendly_promotions/testing_support/factories.rb
-SolidusDevSupport::TestingSupport::Factories.load_for(SolidusFriendlyPromotions::Engine)
-
-# Turbo will try to autoload ActionCable if we allow `app/channels`.
-# Backport of https://github.com/hotwired/turbo-rails/pull/601
-# Can go once `turbo-rails` 2.0.7 is released.
-Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
+require "solidus_friendly_promotions"
 
 Spree::Config.promotions = SolidusFriendlyPromotions.configuration
 
 RSpec.configure do |config|
-  config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
-
-  config.include SolidusFriendlyPromotions::Engine.routes.url_helpers, type: :request
-end
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
+  config.disable_monkey_patching!
+  config.color = true
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
   end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.include Spree::TestingSupport::Preferences
+
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/spec/subscribers/solidus_friendly_promotions/order_promotion_subscriber_spec.rb
+++ b/spec/subscribers/solidus_friendly_promotions/order_promotion_subscriber_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe SolidusFriendlyPromotions::OrderPromotionSubscriber do
   let(:bus) { Omnes::Bus.new }

--- a/spec/system/solidus_friendly_promotions/backend/promotion_categories_spec.rb
+++ b/spec/system/solidus_friendly_promotions/backend/promotion_categories_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Promotion Categories", type: :system do
   stub_authorization!

--- a/spec/system/solidus_friendly_promotions/backend/promotion_code_batches_spec.rb
+++ b/spec/system/solidus_friendly_promotions/backend/promotion_code_batches_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.feature "Promotion Code Batches", partial_double_verification: false do
   stub_authorization!

--- a/spec/system/solidus_friendly_promotions/backend/promotions_spec.rb
+++ b/spec/system/solidus_friendly_promotions/backend/promotions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "Promotions admin", type: :system do
   stub_authorization!


### PR DESCRIPTION
This mirrors what is done in Solidus core, and is cleaner anyways. 

Extracted from #124 