### PR TITLE
Remove `require_promotion_code` override

### DIFF
--- a/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
+++ b/app/decorators/models/solidus_friendly_promotions/adjustment_decorator.rb
@@ -6,15 +6,7 @@ module SolidusFriendlyPromotions
       base.scope :friendly_promotion, -> { where(source_type: "SolidusFriendlyPromotions::Benefit") }
     end
 
-    def friendly_promotion?
-      source_type == "SolidusFriendlyPromotions::Benefit"
-    end
-
     private
-
-    def require_promotion_code?
-      !friendly_promotion? && super
-    end
 
     Spree::Adjustment.prepend self
   end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -49,25 +49,4 @@ RSpec.describe Spree::Adjustment do
       it { is_expected.to be false }
     end
   end
-
-  describe "#friendly_promotion?" do
-    let(:source) { create(:friendly_promotion, :with_adjustable_benefit).benefits.first }
-    let!(:adjustment) { build(:adjustment, source: source) }
-
-    subject { adjustment.friendly_promotion? }
-
-    it { is_expected.to be true }
-
-    context "with a Spree Promotion Action source" do
-      let(:source) { create(:promotion, :with_action).actions.first }
-
-      it { is_expected.to be false }
-    end
-
-    context "with a Tax Rate source" do
-      let(:source) { create(:tax_rate) }
-
-      it { is_expected.to be false }
-    end
-  end
 end


### PR DESCRIPTION
With https://github.com/solidusio/solidus/pull/5800/commits/10b555b13e15e8b81be0863ee877dd9876148a87 merged, we don't need this override anymore, and our build should go green again.