### PR TITLE
Prepare solidus integration

### DIFF
--- a/lib/solidus_friendly_promotions/testing_support/factory_bot.rb
+++ b/lib/solidus_friendly_promotions/testing_support/factory_bot.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "factory_bot"
+begin
+  require "factory_bot_rails"
+rescue LoadError
+end
+
+module SolidusFriendlyPromotions
+  module TestingSupport
+    module FactoryBot
+      SEQUENCES = ["#{::SolidusFriendlyPromotions::Engine.root}/lib/solidus_friendly_promotions/testing_support/sequences.rb"]
+      FACTORIES = Dir["#{::SolidusFriendlyPromotions::Engine.root}/lib/solidus_friendly_promotions/testing_support/factories/**/*_factory.rb"].sort
+      PATHS = SEQUENCES + FACTORIES
+
+      def self.definition_file_paths
+        @paths ||= PATHS.map { |path| path.sub(/.rb\z/, "") }
+      end
+
+      def self.add_definitions!
+        ::FactoryBot.definition_file_paths.unshift(*definition_file_paths).uniq!
+      end
+
+      def self.add_paths_and_load!
+        add_definitions!
+        ::FactoryBot.reload
+      end
+    end
+  end
+end

--- a/solidus_friendly_promotions.gemspec
+++ b/solidus_friendly_promotions.gemspec
@@ -34,10 +34,17 @@ Gem::Specification.new do |spec|
   spec.add_dependency "stimulus-rails", "~> 1.2"
   spec.add_dependency "importmap-rails", "~> 1.2"
   spec.add_dependency "ransack-enum", "~> 1.0"
+
+  spec.add_development_dependency "capybara", "~> 3.29"
+  spec.add_development_dependency "database_cleaner", [">= 1.7", "< 3"]
+  spec.add_development_dependency "factory_bot", ">= 4.8"
+  spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "rspec-activemodel-mocks", "~> 1.0"
   spec.add_development_dependency "rspec-retry"
+  spec.add_development_dependency "rspec-rails", ">= 5.0", "< 7.0"
+  spec.add_development_dependency "selenium-webdriver", "~> 4.11"
   spec.add_development_dependency "shoulda-matchers", "~> 5.3"
-  spec.add_development_dependency "solidus_dev_support", "~> 2.6"
   spec.add_development_dependency "standard", "~> 1.31"
   spec.add_development_dependency "tailwindcss-rails", "~> 2.2"
+  spec.add_development_dependency "puma", ">= 4.3", "< 7.0"
 end


### PR DESCRIPTION
This adds a `solidus_friendly_promotions/testing_support/factory_bot` file and drops the dependency on `solidus_dev_support`.